### PR TITLE
Contributions: refresh PR counts and latest-PR feed

### DIFF
--- a/contributions.json
+++ b/contributions.json
@@ -1,5 +1,5 @@
 {
-  "total_prs": 530,
+  "total_prs": 579,
   "total_contributors": 17,
   "repos_touched": [
     "ecommerce_integrations",
@@ -15,13 +15,13 @@
       "name": "Ravibharathi",
       "avatar": "https://avatars.githubusercontent.com/u/131471282?v=4",
       "profile_url": "https://github.com/ravibharathi656",
-      "total_merged_prs": 92,
+      "total_merged_prs": 98,
       "repos": {
-        "erpnext": 83,
-        "ecommerce_integrations": 1,
+        "erpnext": 87,
         "frappe": 6,
-        "hrms": 1,
-        "payments": 1
+        "payments": 3,
+        "ecommerce_integrations": 1,
+        "hrms": 1
       },
       "summary": "Accounts and payments specialist. Deep work on payment reconciliation, exchange rate handling, POS, bank transactions, and GL entries. Also contributed performance improvements like batch processing for auto bank reconciliation and subscription processing."
     },
@@ -30,10 +30,10 @@
       "name": "Venkatesh",
       "avatar": "https://avatars.githubusercontent.com/u/47534423?v=4",
       "profile_url": "https://github.com/venkat102",
-      "total_merged_prs": 89,
+      "total_merged_prs": 90,
       "repos": {
+        "erpnext": 71,
         "hrms": 16,
-        "erpnext": 70,
         "frappe": 3
       },
       "summary": "Core accounting and payroll contributor. Extensive fixes across payment entries, tax withholding, period closing vouchers, cost center allocation, and multi-currency handling. Strong HRMS work including salary slips, leave encashment, and shift assignments."
@@ -56,9 +56,9 @@
       "name": "Kavin",
       "avatar": "https://avatars.githubusercontent.com/u/78342682?v=4",
       "profile_url": "https://github.com/kavin-114",
-      "total_merged_prs": 55,
+      "total_merged_prs": 57,
       "repos": {
-        "erpnext": 55
+        "erpnext": 57
       },
       "summary": "Stock and manufacturing specialist. Focused on serial/batch handling, pick lists, POS batch calculations, subcontracting, and work order validations. Deep expertise in inventory operations and warehouse management."
     },
@@ -67,9 +67,9 @@
       "name": "Sudharsanan Ashok",
       "avatar": "https://avatars.githubusercontent.com/u/135326972?v=4",
       "profile_url": "https://github.com/Sudharsanan11",
-      "total_merged_prs": 37,
+      "total_merged_prs": 52,
       "repos": {
-        "erpnext": 35,
+        "erpnext": 50,
         "hrms": 2
       },
       "summary": "Manufacturing and stock operations contributor. Work across production plans, work orders, batch quantity calculations, subcontracting orders, and stock reservations. Also contributed to buying workflows and quality inspection."
@@ -79,9 +79,9 @@
       "name": "NaviN",
       "avatar": "https://avatars.githubusercontent.com/u/118178330?v=4",
       "profile_url": "https://github.com/Navin-S-R",
-      "total_merged_prs": 33,
+      "total_merged_prs": 35,
       "repos": {
-        "erpnext": 32,
+        "erpnext": 34,
         "frappe": 1
       },
       "summary": "Asset management and financial reporting contributor. Key work on asset depreciation, capitalization, partial asset sales, and gross profit reporting. Also improved payment reconciliation and standardized cost center handling across transactions."
@@ -94,10 +94,21 @@
       "total_merged_prs": 33,
       "repos": {
         "erpnext": 25,
-        "hrms": 2,
-        "frappe": 6
+        "frappe": 6,
+        "hrms": 2
       },
       "summary": "Full-stack ERPNext contributor across stock, manufacturing, and framework. Fixes in barcode scanning, warehouse handling, period closing, and quality inspection. Also contributed to Frappe framework UI including form sidebar and data exporter improvements."
+    },
+    {
+      "username": "Pandiyan5273",
+      "name": "Pandiyan P",
+      "avatar": "https://avatars.githubusercontent.com/u/171273338?v=4",
+      "profile_url": "https://github.com/Pandiyan5273",
+      "total_merged_prs": 26,
+      "repos": {
+        "erpnext": 26
+      },
+      "summary": "Stock and manufacturing contributor. Focused on warehouse mapping, barcode scanning, UOM handling, and work order improvements. Clean, targeted fixes in stock entry and subassembly workflows."
     },
     {
       "username": "Bhavan23",
@@ -106,24 +117,24 @@
       "profile_url": "https://github.com/Bhavan23",
       "total_merged_prs": 25,
       "repos": {
-        "frappe": 1,
         "erpnext": 21,
+        "ecommerce_integrations": 1,
+        "frappe": 1,
         "payments": 1,
-        "webshop": 1,
-        "ecommerce_integrations": 1
+        "webshop": 1
       },
-      "summary": "Broadest ecosystem coverage \u2014 contributed across 6 repos including frappe, erpnext, payments, webshop, ecommerce_integrations, and frappe_docker. Key work on payment reconciliation, budget management, bank reconciliation, and inter-company transactions."
+      "summary": "Broadest ecosystem coverage — contributed across 6 repos including frappe, erpnext, payments, webshop, ecommerce_integrations, and frappe_docker. Key work on payment reconciliation, budget management, bank reconciliation, and inter-company transactions."
     },
     {
       "username": "nareshkannasln",
       "name": "Nareshkanna S",
       "avatar": "https://avatars.githubusercontent.com/u/159678797?v=4",
       "profile_url": "https://github.com/nareshkannasln",
-      "total_merged_prs": 23,
+      "total_merged_prs": 25,
       "repos": {
-        "hrms": 21,
-        "frappe": 1,
-        "erpnext": 1
+        "hrms": 23,
+        "erpnext": 1,
+        "frappe": 1
       },
       "summary": "HRMS specialist. Contributions across expense claims, salary structure, leave management, gratuity, and attendance. Also built job opening template auto-fetch and improved the salary register report."
     },
@@ -132,25 +143,27 @@
       "name": "Sowmya",
       "avatar": "https://avatars.githubusercontent.com/u/106989392?v=4",
       "profile_url": "https://github.com/SowmyaArunachalam",
-      "total_merged_prs": 22,
+      "total_merged_prs": 23,
       "repos": {
-        "erpnext": 18,
-        "frappe": 1,
+        "erpnext": 19,
         "ecommerce_integrations": 2,
+        "frappe": 1,
         "hrms": 1
       },
       "summary": "Versatile contributor across selling, assets, and accounts. Built features like configurable asset depreciation notifications, attendance permissions, and default age ranges in accounts. Fixes across sales orders, material requests, and CI infrastructure."
     },
     {
-      "username": "Pandiyan5273",
-      "name": "Pandiyan P",
-      "avatar": "https://avatars.githubusercontent.com/u/171273338?v=4",
-      "profile_url": "https://github.com/Pandiyan5273",
-      "total_merged_prs": 14,
+      "username": "ervishnucs",
+      "name": "Vishnu Priya Baskaran",
+      "avatar": "https://avatars.githubusercontent.com/u/145791817?v=4",
+      "profile_url": "https://github.com/ervishnucs",
+      "total_merged_prs": 17,
       "repos": {
-        "erpnext": 14
+        "erpnext": 14,
+        "ecommerce_integrations": 2,
+        "frappe": 1
       },
-      "summary": "Stock and manufacturing contributor. Focused on warehouse mapping, barcode scanning, UOM handling, and work order improvements. Clean, targeted fixes in stock entry and subassembly workflows."
+      "summary": "Accounts and ecommerce contributor. Fixes in payment requests, budget variance reporting, bank reconciliation, and Bootstrap layout handling. Also worked on ecommerce integrations and framework test infrastructure."
     },
     {
       "username": "Karuppasamy923",
@@ -160,24 +173,11 @@
       "total_merged_prs": 13,
       "repos": {
         "erpnext": 10,
-        "hrms": 1,
         "frappe": 1,
+        "hrms": 1,
         "payments": 1
       },
       "summary": "Contributed across accounts, payments, and integrations. Built MT940 bank statement import, pegged currency support, and Razorpay currency extensions. Work on inter-company transaction validation and trend reports."
-    },
-    {
-      "username": "ervishnucs",
-      "name": "Vishnu Priya Baskaran",
-      "avatar": "https://avatars.githubusercontent.com/u/145791817?v=4",
-      "profile_url": "https://github.com/ervishnucs",
-      "total_merged_prs": 11,
-      "repos": {
-        "erpnext": 8,
-        "ecommerce_integrations": 2,
-        "frappe": 1
-      },
-      "summary": "Accounts and ecommerce contributor. Fixes in payment requests, budget variance reporting, bank reconciliation, and Bootstrap layout handling. Also worked on ecommerce integrations and framework test infrastructure."
     },
     {
       "username": "rs-rethik",
@@ -198,8 +198,8 @@
       "profile_url": "https://github.com/DHINESH00",
       "total_merged_prs": 6,
       "repos": {
-        "frappe": 1,
-        "erpnext": 5
+        "erpnext": 5,
+        "frappe": 1
       },
       "summary": "Focused contributions on pricing and bank reconciliation. Fixes in pricing rule application, discount handling, currency updates, and the bank reconciliation tool."
     },
@@ -208,11 +208,11 @@
       "name": "Sudarshan",
       "avatar": "https://avatars.githubusercontent.com/u/73628063?v=4",
       "profile_url": "https://github.com/sudarsan2001",
-      "total_merged_prs": 4,
+      "total_merged_prs": 6,
       "repos": {
-        "hrms": 1,
+        "erpnext": 4,
         "frappe": 1,
-        "erpnext": 2
+        "hrms": 1
       },
       "summary": "HRMS and accounts contributor. Fixes in holiday list handling, asset depreciation schedules, GL entry currency, and translation improvements for link fields."
     },

--- a/recent-prs.json
+++ b/recent-prs.json
@@ -1,142 +1,142 @@
 [
   {
-    "title": "fix(manufacturing): show returned qty in progress bar",
+    "title": "fix(stock): show available qty in warehouse link field",
     "repo": "erpnext",
     "author": "Sudharsanan Ashok",
-    "url": "https://github.com/frappe/erpnext/pull/53234",
-    "date": "2026-03-08"
+    "url": "https://github.com/frappe/erpnext/pull/54474",
+    "date": "2026-04-23"
   },
   {
-    "title": "fix: update item row delivery dates when header delivery date changes in sales order",
-    "repo": "erpnext",
-    "author": "Pandiyan P",
-    "url": "https://github.com/frappe/erpnext/pull/53235",
-    "date": "2026-03-08"
-  },
-  {
-    "title": "fix: fetch holiday list of an employee based on month end date filter\u2026",
-    "repo": "hrms",
-    "author": "Sudarshan",
-    "url": "https://github.com/frappe/hrms/pull/4199",
-    "date": "2026-03-06"
-  },
-  {
-    "title": "fix(manufacturing): ignore sales order validation for subassembly item",
-    "repo": "erpnext",
-    "author": "Kavin",
-    "url": "https://github.com/frappe/erpnext/pull/53176",
-    "date": "2026-03-05"
-  },
-  {
-    "title": "fix: allow payment_request to be created in draft",
-    "repo": "erpnext",
-    "author": "Vishnu Priya Baskaran",
-    "url": "https://github.com/frappe/erpnext/pull/53160",
-    "date": "2026-03-04"
-  },
-  {
-    "title": "fix(selling): handle selling price validation for FG item ",
-    "repo": "erpnext",
-    "author": "Kavin",
-    "url": "https://github.com/frappe/erpnext/pull/53132",
-    "date": "2026-03-03"
-  },
-  {
-    "title": "fix: avoid circular dependency",
-    "repo": "erpnext",
-    "author": "Vishnu Priya Baskaran",
-    "url": "https://github.com/frappe/erpnext/pull/53109",
-    "date": "2026-03-03"
-  },
-  {
-    "title": "fix: populate mr owner and set po owner as fallback",
-    "repo": "erpnext",
-    "author": "Kavin",
-    "url": "https://github.com/frappe/erpnext/pull/53099",
-    "date": "2026-03-02"
-  },
-  {
-    "title": "perf: add index on reference_purchase_receipt column",
-    "repo": "erpnext",
-    "author": "Kavin",
-    "url": "https://github.com/frappe/erpnext/pull/53087",
-    "date": "2026-03-02"
-  },
-  {
-    "title": "fix(manufacturing): ignore sales order validation for subassembly item",
-    "repo": "erpnext",
-    "author": "Sudharsanan Ashok",
-    "url": "https://github.com/frappe/erpnext/pull/53084",
-    "date": "2026-03-02"
-  },
-  {
-    "title": "fix(accounts): set posting time to get incoming rate",
-    "repo": "erpnext",
-    "author": "Sudharsanan Ashok",
-    "url": "https://github.com/frappe/erpnext/pull/53072",
-    "date": "2026-03-01"
-  },
-  {
-    "title": "fix(gross-profit): apply precision-based rounding to grouped totals",
-    "repo": "erpnext",
-    "author": "NaviN",
-    "url": "https://github.com/frappe/erpnext/pull/53071",
-    "date": "2026-03-01"
-  },
-  {
-    "title": "fix: handle html email template separately in RFQ to avoid jinja cont\u2026",
-    "repo": "erpnext",
-    "author": "Pugazhendhi Velu",
-    "url": "https://github.com/frappe/erpnext/pull/53070",
-    "date": "2026-03-01"
-  },
-  {
-    "title": "fix(stock): pass company to avoid document naming rule issue in QI",
-    "repo": "erpnext",
-    "author": "Kavin",
-    "url": "https://github.com/frappe/erpnext/pull/53037",
-    "date": "2026-02-28"
-  },
-  {
-    "title": "fix: skip empty dimension values in exchange gain loss",
-    "repo": "erpnext",
-    "author": "Ravibharathi",
-    "url": "https://github.com/frappe/erpnext/pull/52896",
-    "date": "2026-02-23"
-  },
-  {
-    "title": "fix(work_order): update returned qty on work order",
-    "repo": "erpnext",
-    "author": "Pandiyan P",
-    "url": "https://github.com/frappe/erpnext/pull/52880",
-    "date": "2026-02-23"
-  },
-  {
-    "title": "fix(manufacturing): remove delete query of job card & batch and serial no ",
-    "repo": "erpnext",
-    "author": "Sudharsanan Ashok",
-    "url": "https://github.com/frappe/erpnext/pull/52840",
-    "date": "2026-02-20"
-  },
-  {
-    "title": "fix(patch): check user type existence",
+    "title": "fix(attendance-request): update days in attendance request list",
     "repo": "hrms",
     "author": "Nareshkanna S",
-    "url": "https://github.com/frappe/hrms/pull/4158",
-    "date": "2026-02-20"
+    "url": "https://github.com/frappe/hrms/pull/4424",
+    "date": "2026-04-22"
   },
   {
-    "title": "fix(sales-order): update quotation status while cancelling sales order",
+    "title": "fix(vat audit report): fallback to item name when item code is missing",
     "repo": "erpnext",
-    "author": "Sowmya",
-    "url": "https://github.com/frappe/erpnext/pull/52822",
-    "date": "2026-02-20"
+    "author": "Ravibharathi",
+    "url": "https://github.com/frappe/erpnext/pull/54049",
+    "date": "2026-04-20"
   },
   {
-    "title": "fix(manufacturing): update closed status for current work order before calculating planned qty",
+    "title": "fix: fetch get_item_tax_template while update items",
+    "repo": "erpnext",
+    "author": "Vishnu Priya Baskaran",
+    "url": "https://github.com/frappe/erpnext/pull/53708",
+    "date": "2026-04-20"
+  },
+  {
+    "title": "fix: fetch item tax template from item group when creating item",
+    "repo": "erpnext",
+    "author": "Pandiyan P",
+    "url": "https://github.com/frappe/erpnext/pull/54405",
+    "date": "2026-04-20"
+  },
+  {
+    "title": "fix: validate south africa company in vat audit report",
+    "repo": "erpnext",
+    "author": "Ravibharathi",
+    "url": "https://github.com/frappe/erpnext/pull/54030",
+    "date": "2026-04-19"
+  },
+  {
+    "title": "fix: fetch item tax template from item group when creating item",
+    "repo": "erpnext",
+    "author": "Pandiyan P",
+    "url": "https://github.com/frappe/erpnext/pull/54258",
+    "date": "2026-04-18"
+  },
+  {
+    "title": "fix(manufacturing): handle empty list in query builder",
+    "repo": "erpnext",
+    "author": "Pandiyan P",
+    "url": "https://github.com/frappe/erpnext/pull/54355",
+    "date": "2026-04-17"
+  },
+  {
+    "title": "feat: add option to create production plan from sales order",
+    "repo": "erpnext",
+    "author": "Venkatesh",
+    "url": "https://github.com/frappe/erpnext/pull/53662",
+    "date": "2026-04-16"
+  },
+  {
+    "title": "Revert \"fix: sync paid and received amount\"",
+    "repo": "erpnext",
+    "author": "Vishnu Priya Baskaran",
+    "url": "https://github.com/frappe/erpnext/pull/54238",
+    "date": "2026-04-14"
+  },
+  {
+    "title": "fix(stock): remove float precision to fix precision issue",
     "repo": "erpnext",
     "author": "Sudharsanan Ashok",
-    "url": "https://github.com/frappe/erpnext/pull/52803",
-    "date": "2026-02-19"
+    "url": "https://github.com/frappe/erpnext/pull/54284",
+    "date": "2026-04-14"
+  },
+  {
+    "title": "fix(stock): update bin to zero when no previous sle exists",
+    "repo": "erpnext",
+    "author": "Sudharsanan Ashok",
+    "url": "https://github.com/frappe/erpnext/pull/54236",
+    "date": "2026-04-13"
+  },
+  {
+    "title": "fix: make operation mandatory when any sub operation row is added",
+    "repo": "erpnext",
+    "author": "Sudarshan",
+    "url": "https://github.com/frappe/erpnext/pull/54245",
+    "date": "2026-04-13"
+  },
+  {
+    "title": "fix(sales invoice): toggle Get Items From button based on is_return and POS view",
+    "repo": "erpnext",
+    "author": "NaviN",
+    "url": "https://github.com/frappe/erpnext/pull/52594",
+    "date": "2026-04-08"
+  },
+  {
+    "title": "fix(manufacturing): check remaining qty to calculate operating cost",
+    "repo": "erpnext",
+    "author": "Sudharsanan Ashok",
+    "url": "https://github.com/frappe/erpnext/pull/53983",
+    "date": "2026-04-08"
+  },
+  {
+    "title": "fix(stock): ignore delivery note on delivery trip on_cancel trigger",
+    "repo": "erpnext",
+    "author": "Sudharsanan Ashok",
+    "url": "https://github.com/frappe/erpnext/pull/54120",
+    "date": "2026-04-08"
+  },
+  {
+    "title": "fix: preserve asset movement field properties after save",
+    "repo": "erpnext",
+    "author": "Ravibharathi",
+    "url": "https://github.com/frappe/erpnext/pull/54103",
+    "date": "2026-04-08"
+  },
+  {
+    "title": "fix: sync paid and received amount",
+    "repo": "erpnext",
+    "author": "Vishnu Priya Baskaran",
+    "url": "https://github.com/frappe/erpnext/pull/53039",
+    "date": "2026-04-07"
+  },
+  {
+    "title": "fix(salary_slip): update round() for remaining sub period",
+    "repo": "hrms",
+    "author": "Nareshkanna S",
+    "url": "https://github.com/frappe/hrms/pull/4243",
+    "date": "2026-04-07"
+  },
+  {
+    "title": "fix: remove null from link_filters",
+    "repo": "erpnext",
+    "author": "Vishnu Priya Baskaran",
+    "url": "https://github.com/frappe/erpnext/pull/53394",
+    "date": "2026-04-07"
   }
 ]


### PR DESCRIPTION
Refreshed contributions.json (530 → 579 merged PRs across 17 devs) and recent-prs.json (top 20, up to 2026-04-23) from GitHub Search API.

## Summary                                                
  - contributions.json: refreshed all 17 contributors via GitHub Search API (total merged PRs 530 → 579)
  - recent-prs.json: refreshed top 20 most-recent merged PRs (latest 2026-04-23)                        
  - 3 users spot-checked with independent per-repo queries — counts match                                                                                                                                             
                                                                                                                                                                                                                      
  ## Test plan                                                                                                                                                                                                        
  - [x] Inspect the home page scrolling ticker for updated PR titles/dates                                                                                                                                            
  - [x] Verify contributor counts render correctly (top 3: ravibharathi656 98, venkat102 90, l0gesh29 63)    