### PR TITLE
Redesign site to lens design language + add Aerele design system skill

### DIFF
--- a/.claude/skills/aerele-design/SKILL.md
+++ b/.claude/skills/aerele-design/SKILL.md
@@ -1,0 +1,686 @@
+---
+name: aerele-design
+description: Stack-agnostic design system for Aerele-branded web products. Apply whenever building or editing a marketing site, landing page, or web UI that should match the Aerele family look — navy-slate + emerald palette, Inter + JetBrains Mono, white fixed nav, dark hero with a single emerald accent, restrained semibold typography, 1280px max container. Translate the tokens to whatever styling approach the target product uses (Tailwind, plain CSS, CSS-in-JS, CSS modules, SCSS, etc.).
+---
+
+# Aerele Design System
+
+A shareable set of rules for building Aerele-branded web products. The reference implementation is `aerele.in`, which uses Tailwind. The rules below are **stack-agnostic** — they define the intended visual outcome as raw tokens and principles. Use whatever styling tech your product already uses; just match the values.
+
+**Philosophy in one line:** elegant and restrained. Quiet confidence, not marketing noise. Our values show in the work — the typography shouldn't shout them.
+
+**When to apply:** any time you're building or editing presentation layers in an Aerele product. If you can't follow a rule for a technical reason, document the deviation in the PR.
+
+---
+
+## How to use this document
+
+1. Read **Section 1 (Tokens)** and **Section 2 (Typography rules)** — these are the non-negotiables.
+2. Map the tokens to your stack's idiom. You'll find reference implementations in the appendices for Tailwind, plain CSS custom properties, and a JSON token file.
+3. When building a component, skim **Section 4 (Component patterns)**. Each pattern describes the *behavior and values*, not the code.
+4. Before shipping, run through **Section 7 (Anti-patterns)** — it's the shortlist of things we learned the hard way.
+
+The tokens are the contract. The appendix code is just example spellings.
+
+---
+
+## 1. Design tokens
+
+These are the raw values. Any stack should expose them as variables / constants / tokens and consume them from there. Do not hardcode hex or rem values elsewhere in the product.
+
+### 1.1 Colors
+
+**Navy-slate scale (`ae`) — neutral surfaces, borders, text.**
+
+| Token | Hex | Typical use |
+|---|---|---|
+| `ae-50`  | `#f7f8fb` | Page background (light theme) |
+| `ae-100` | `#eef2fb` | Light hover, faint numeric markers |
+| `ae-200` | `#e4e9f5` | Borders, dividers on light |
+| `ae-300` | `#c9d2e8` | Borders on dark sections, secondary button border on light |
+| `ae-400` | `#94a3b8` | Muted text, icons, eyebrow/kicker labels |
+| `ae-500` | `#64748b` | Body paragraph text on light |
+| `ae-600` | `#475569` | Nav link text |
+| `ae-700` | `#1e293b` | Strong text on light (links, emphasis) |
+| `ae-800` | `#0a1a3f` | Hover state for `ae-900` elements |
+| `ae-900` | `#060f2b` | Dark hero background, navy CTA button fill |
+| `ae-950` | `#05102a` | Deepest surface (code/terminal window bg) |
+
+**Emerald scale (`brand`) — accent only.**
+
+| Token | Hex | Typical use |
+|---|---|---|
+| `brand-400` | `#34d399` | Accent word in hero H1, "live" badge text |
+| `brand-500` | `#10b981` | Primary CTA background, "live" indicator dot |
+| `brand-600` | `#059669` | Primary CTA hover |
+
+Full emerald scale (rarely needed, provided for completeness): `brand-50 #ecfdf5 · 100 #d1fae5 · 200 #a7f3d0 · 300 #6ee7b7 · 700 #047857 · 800 #065f46 · 900 #064e3b`.
+
+**Accent rule:** brand is an accent, never a surface. One emerald accent per hero (one word, one CTA). One per pricing tier ("Popular"). One "live" indicator where real-time data is shown. That's the full brand budget on any given page.
+
+### 1.2 Typography
+
+**Families**
+
+| Role | Family | Fallbacks |
+|---|---|---|
+| Sans (primary) | Inter | `system-ui, -apple-system, sans-serif` |
+| Mono (code, logs, step numbers) | JetBrains Mono | `ui-monospace, SFMono-Regular, Menlo, monospace` |
+
+Load from Google Fonts (or self-host). Weights needed: Inter 400 / 500 / 600 / 700 / 800; JetBrains Mono 400 / 500 / 600.
+
+**Weight rule:** default to **600 (semibold)** for all display typography. Reserve 700 (bold) and 800 (extrabold) for small stat numbers where weight is the only hierarchy cue. Never use 900 (black).
+
+Why: heavy weights at large sizes read as shouting. Semibold at large sizes reads as confident.
+
+**Type scale**
+
+| Role | Size | Weight | Line-height | Letter-spacing |
+|---|---|---|---|---|
+| Hero H1 | fluid: `clamp(1.5rem, 4.4vw, 3.25rem)` (24px → 52px) | 600 | 1.15 | tight (`-0.02em`) |
+| Section H2 | 1.625rem (26px) mobile → 1.875rem (30px) `sm` → 2.25rem (36px) `md+` | 600 | 1.2 | tight (`-0.02em`) |
+| Card H3 | 1rem (16px) | 600 | 1.4 | normal |
+| Hero lead (body) | 1.125rem (18px) | 400 | 1.625 | normal |
+| Section body | 0.875rem (14px) or 1rem (16px) | 400 | 1.625 | normal |
+| Eyebrow / kicker | 0.75rem (12px) | 500 | 1.4 | wide (`0.1em` or more), UPPERCASE |
+| Mono labels | 0.6875rem–0.75rem (11–12px) | 400–500 | 1.4 | normal |
+
+**The clamp rule:** hero H1 must use `clamp()` for fluid sizing. Flat `text-7xl` or `font-size: 72px` breaks on small viewports and looks crude on huge ones.
+
+### 1.3 Spacing scale
+
+Using a 4px base. Prefer these steps; don't invent new values.
+
+| Token | Value | px |
+|---|---|---|
+| `space-1` | 0.25rem | 4 |
+| `space-2` | 0.5rem | 8 |
+| `space-3` | 0.75rem | 12 |
+| `space-4` | 1rem | 16 |
+| `space-5` | 1.25rem | 20 |
+| `space-6` | 1.5rem | 24 |
+| `space-7` | 1.75rem | 28 |
+| `space-8` | 2rem | 32 |
+| `space-10` | 2.5rem | 40 |
+| `space-12` | 3rem | 48 |
+| `space-16` | 4rem | 64 |
+| `space-20` | 5rem | 80 |
+| `space-24` | 6rem | 96 |
+| `space-28` | 7rem | 112 |
+| `space-32` | 8rem | 128 |
+
+**Component defaults:**
+- Card padding: 28px (`space-7`). Small cards: 20px (`space-5`).
+- Section vertical padding: 80px mobile / 112px ≥ `sm` (`space-20` / `space-28`). Final CTA section: 96 / 128 (`space-24` / `space-32`).
+- Container horizontal padding: 24px mobile / 32px ≥ `sm` (`space-6` / `space-8`).
+- Nav height: approximately 72px (via 16px vertical padding on the inner row).
+
+### 1.4 Radii
+
+| Token | Value | Use |
+|---|---|---|
+| `radius-sm` | 0.375rem (6px) | Small pills, badges |
+| `radius-md` | 0.5rem (8px) | Buttons, inputs |
+| `radius-lg` | 0.75rem (12px) | Cards, code/terminal windows |
+| `radius-xl` | 1rem (16px) | Large cards, video embeds |
+| `radius-full` | 9999px | Status pills, traffic-light dots, circular badges |
+
+**Rule:** action buttons use `radius-md` (8px), not full-pill. Pill buttons read as dated.
+
+### 1.5 Breakpoints
+
+Follow the Tailwind-style defaults (they're widely understood):
+
+| Name | Min-width |
+|---|---|
+| `sm` | 640px |
+| `md` | 768px |
+| `lg` | 1024px |
+| `xl` | 1280px |
+| `2xl` | 1536px |
+
+Mobile-first: write base styles for the smallest viewport and layer up at breakpoints.
+
+### 1.6 Layout
+
+- **Container max-width: 1280px.** This is the single most important layout token.
+- Apply it to the nav's inner row, every section's inner row, and the footer's inner row. No exceptions.
+- Horizontal padding inside the container: 24px (mobile) / 32px (`sm+`).
+- The container is always centered (`margin-inline: auto`).
+
+Inner content *inside* a section may have its own narrower max-width for readability (e.g., 768px for a centered heading block, 576px for a hero text column). That's fine — the 1280px rule is about the *outer* section container.
+
+### 1.7 Elevation and glows
+
+Use elevation sparingly. Flat surfaces are the default.
+
+- Cards: 1px border in `ae-200/60` (ae-200 at 60% opacity). No shadow by default.
+- Featured/popular card: 1px ring in `brand-500/20` + soft emerald shadow (`0 20px 25px -5px rgba(16,185,129,0.1)`).
+- Terminal/code window: `0 25px 50px -12px rgba(0,0,0,0.4)`.
+- **Hero glow** (the one gradient in the system):
+  ```
+  radial-gradient(ellipse 80% 60% at 30% 30%, rgba(16,185,129,0.08), transparent 70%),
+  radial-gradient(ellipse 60% 50% at 80% 20%, rgba(26,50,116,0.4), transparent 70%)
+  ```
+  Layered as an absolutely positioned overlay inside the dark hero. Two soft ellipses: emerald at top-left, deep navy at top-right.
+
+---
+
+## 2. Typography rules (prose)
+
+1. One family for display and body (Inter). Mono (JetBrains Mono) only for terminal windows, code snippets, numeric step markers, and log-like content.
+2. Weight defaults to 600 (semibold) for all display sizes. 400 for body. Never 800+ on anything bigger than a stat number.
+3. Hero H1 uses `clamp()` fluid sizing. Section H2 steps through three breakpoints (26 / 30 / 36 px). Card H3 is a flat 16px.
+4. Headings use `letter-spacing: -0.02em` ("tracking-tight"). Body is neutral.
+5. Eyebrow labels (the tiny all-caps line above an H2) use `letter-spacing: 0.1em` or more, and `ae-400` color.
+6. Line-height: 1.15 for hero H1, 1.2 for section H2, 1.4 for H3 and mono, 1.625 for body paragraphs.
+7. Never center long body copy. Centered headings are fine; centered paragraphs longer than ~2 lines read poorly.
+
+---
+
+## 3. Layout rules (prose)
+
+1. **Single container width (1280px) across the whole product.** Nav, sections, footer all use the same outer container. Mixing widths between nav and sections is the most common design bug — it makes wide viewports look misaligned.
+2. **Content inside a section may have narrower inner wrappers** for readability (a 768px centered heading block, a 576px hero text column). That's encouraged. The 1280px rule is only about the outer boundary.
+3. **Vertical rhythm:** sections are 80px / 112px (mobile / desktop) top and bottom. Hero adds top padding for the fixed nav.
+4. **Horizontal rhythm:** 24px / 32px container padding. Gaps between columns: 24–40px depending on density.
+5. **Hero when it has a right-column visual:** use a flex row with `justify-content: space-between` so the visual's right edge aligns with the container's right edge (same edge as the nav's CTA button).
+6. **Footer container shares nav's width and padding.**
+
+---
+
+## 4. Component patterns
+
+Each pattern is described behaviorally (values, not syntax). Implementations in any stack should match these values. Copy-paste-ready reference code is in the appendices.
+
+### 4.1 Nav (fixed, white)
+
+- Position: fixed top, full width.
+- Background: white at 90% opacity with a 12px backdrop blur. *Never* dark — a dark nav over a dark hero disappears.
+- Bottom border: 1px `ae-200` at 60% opacity.
+- Height: approximately 72px (16px vertical padding on the inner row).
+- Inner row: 1280px max container, horizontal padding 24/32px.
+- Left: logo mark + wordmark. Wordmark is 16px / weight 600 / `ae-900`.
+- Right (≥ `sm`): inline nav links at 14px / weight 500 / `ae-600`, hover `ae-900`, gap 32px between links.
+- Primary CTA button at the right end: **navy** fill (`ae-900`), white text, 8px radius, 16×32px padding, 600 weight, arrow (→) on the right. Hover: `ae-800`.
+- Primary CTA uses *navy* in the nav — emerald is reserved for the hero / in-page CTAs. This keeps the emerald signal rare and intentional.
+- Below `sm`: replace the inline links with a hamburger button (20×20 icon, `ae-600`).
+
+### 4.2 Hero (dark navy with glow)
+
+- Background: `ae-900` navy, white text.
+- Radial glow overlay: the two-ellipse gradient from §1.7, absolutely positioned inside the section, pointer-events none.
+- Top padding: 112px (mobile) / 128px (`sm+`), to clear the fixed nav plus breathing room. Bottom padding: 80 / 96px.
+- Content row: flex column on mobile, flex row `≥ lg`. When there's a right-column visual, use `justify-between`.
+- Eyebrow pill: 11px UPPERCASE label with a pulsing 6×6px `brand-500` dot. Background `rgba(255,255,255,0.05)`, 1px border `rgba(255,255,255,0.1)`, full radius.
+- H1: `clamp(1.5rem, 4.4vw, 3.25rem)`, weight 600, line-height 1.15, tracking tight. Plain white except for **exactly one accent word** colored `brand-400`.
+- Lead paragraph: 18px, `ae-200`, line-height 1.625, max-width 576px.
+- Optional supporting paragraph below: 16px, `ae-400`.
+- CTA row: primary button + secondary button.
+  - Primary (emerald): `brand-500` fill, white text, 8px radius, 10×20px padding, 14px / weight 500. Hover `brand-600`.
+  - Secondary (outlined on dark): transparent fill, 1px border `rgba(255,255,255,0.15)`, white text. Hover: background `rgba(255,255,255,0.05)`.
+- Optional right-column visual: a screenshot, illustration, or terminal window (see §4.6). Width 560px max, aligned to container right edge.
+
+### 4.3 Section heading block
+
+The three-line header that precedes most sections.
+
+- Centered, max-width 672px, auto margins.
+- Line 1: eyebrow — 12px UPPERCASE, `ae-400`, wide letter-spacing, 12px margin-bottom.
+- Line 2: section H2 — 26 / 30 / 36px responsive, weight 600, tracking tight, line-height 1.2, `ae-950`.
+- Line 3 (optional): 14px supporting text, `ae-500`, 12px margin-top.
+
+### 4.4 Cards (three variants)
+
+**Default card (light surface)**
+- Background: white.
+- Border: 1px `ae-200/60`.
+- Radius: 12px.
+- Padding: 28px (`space-7`).
+- H3 (if present): 16px / weight 600 / `ae-950` / 8px margin-bottom.
+- Body: 14px / `ae-500` / line-height 1.625.
+
+**Featured / "Popular" card (dark surface with emerald accent)**
+- Background: `ae-900`.
+- Ring: 1px `brand-500` at 20% opacity.
+- Shadow: soft emerald drop shadow at 10% opacity.
+- Same radius/padding as default.
+- Body text: `ae-200`.
+- "Popular" badge: `brand-500` fill, white text, full radius, 10px uppercase tracked label.
+
+**Numbered step card (process / how-it-works)**
+- Default card shell (white, 1px border, 12px radius, 28px padding).
+- Leading element: a large monospace digit. Size 48px (`font-size: 3rem`). Weight 700. Color **`ae-100`** (deliberately faint — it's an anchor, not a shout). Line-height 1.0. 16px margin-bottom.
+- Followed by H3 + body as usual.
+
+### 4.5 Buttons
+
+Four canonical button styles. Don't invent a fifth.
+
+| Variant | Fill | Text | Border | Radius | Padding | Size |
+|---|---|---|---|---|---|---|
+| Primary — page CTA | `brand-500`, hover `brand-600` | white | none | 8px | 10×20px | 14px / 500 |
+| Primary — nav CTA | `ae-900`, hover `ae-800` | white | none | 8px | 8×16px | 14px / 600 |
+| Secondary — on dark | transparent, hover 5% white | white | 1px `rgba(255,255,255,0.15)` | 8px | 10×20px | 14px / 500 |
+| Secondary — on light | transparent, hover white | `ae-800` | 1px `ae-300`, hover `ae-400` | 8px | 10×20px | 14px / 500 |
+
+**Rules:**
+- Always include a trailing arrow (`→`) on primary CTAs that move the user forward.
+- Never `border-radius: 9999px` on action buttons. Use 8px. (9999px is reserved for status pills and dots.)
+- Hover states change only color. Never padding, radius, or transform.
+
+### 4.6 Terminal / log window (social-proof widget)
+
+When showing live or semi-live data (merged PRs, deploy log, activity feed), use a Mac-terminal-style window. It reads as authentic proof rather than a marketing claim.
+
+- Background: `ae-950` (deepest navy).
+- Border: 1px `rgba(255,255,255,0.1)`.
+- Radius: 12px.
+- Shadow: heavy (`0 25px 50px -12px rgba(0,0,0,0.4)`).
+- Header row: 48px tall, 16px horizontal padding, bottom border 1px `rgba(255,255,255,0.05)`, subtle darker background (`rgba(0,0,0,0.3)`).
+  - Three traffic-light dots, 10px diameter, left-aligned, gap 6px. **Exact colors** (macOS reference): `#ff5f57 #febc2e #28c840`. Do not alter.
+  - Label after the dots: 11px mono, `ae-300`, looks like a shell command (`tail -f something.log`). 12px left margin.
+  - Optional "live" indicator at the right end: 6px `brand-500` pulsing dot + 10px UPPERCASE "live" label in `brand-400`.
+- Body: scrolling content area, 12px top padding, fades at top and bottom with small `ae-950→transparent` gradients.
+
+---
+
+## 5. Motion
+
+- Entrance: fade-in with a 16px translate-up. Duration 500ms, ease. Triggered on scroll via IntersectionObserver.
+- Live indicators: 2s pulse animation on the brand-500 dot.
+- Vertical auto-scroll: only for genuinely-live content (activity tickers). 50s linear infinite is the reference speed. Pause on hover.
+- No parallax. No auto-rotating carousels. No anything that moves without user action.
+- Transitions: `transition: color 150ms, background-color 150ms, border-color 150ms`. Don't transition padding, width, or transform on hover.
+
+---
+
+## 6. Content patterns
+
+Reuse these. Don't invent new section archetypes unless the product genuinely needs one.
+
+- **Section header (eyebrow → H2 → sub)**, as in §4.3.
+- **Three-up feature/pricing grid.** Three cards, same width. If one is featured, it gets the dark variant. Two or four tiers: the pattern still holds — one is visually dominant.
+- **Numbered process cards (01 / 02 / 03)** with faint mono digits. See §4.4.
+- **Social-proof bar:** eyebrow ("Companies that chose …"), then a flex row of company *names* (not logos) separated by a middle-dot `·`. Only use logos if every client has granted permission *and* you can keep their visual weights consistent.
+- **FAQ:** native `<details>` elements with a chevron that rotates 180° on open. No JS accordion library.
+- **Live activity ticker:** terminal window pattern (§4.6) containing a vertically scrolling list of real events with repo/author metadata.
+
+---
+
+## 7. Anti-patterns
+
+These are mistakes we've made and undone. Learn from them.
+
+1. **Heavy weights (700+) on hero or section headings.** Shouts. Use 600.
+2. **Mismatched container widths between nav and sections.** Nav 1024px + sections 1280px → the page doesn't line up on wide screens. Pick one (always 1280).
+3. **Inner max-widths narrower than the section that make card grids float in the middle** of a wider section. If pricing is inside a 1280px section, pricing fills 1280px. Don't cap it at 896px centered — it looks narrower than the nav.
+4. **Flat `font-size: 72px` on hero H1.** Breaks on mobile, crude on 4K. Always `clamp()`.
+5. **Dark nav over a dark hero.** The nav disappears. White nav is the rule.
+6. **More than one emerald accent per hero headline.** Dilutes the signal. Pick one word.
+7. **`border-radius: 9999px` on action buttons.** Dated. Use 8px.
+8. **Subpages that skip the dark hero.** They feel like a different site. Every top-level page gets the same hero treatment, even when the hero content is short.
+9. **Ad-hoc emerald / green shades.** Don't reach for `#22c55e` or a framework's default green. Use `brand-400/500/600` exclusively. Centralize.
+10. **Gradients anywhere except the hero glow.** Gradients age fast. Flat + one subtle radial glow is the whole atmospheric budget.
+
+---
+
+## 8. Mobile
+
+- Test at 375px viewport width (iPhone SE). If text clips, the heading is too large or a wrapper is missing a min-width-0 / flex-shrink fix.
+- Nav: collapse everything behind a hamburger at `sm` (640px). Don't try to keep five links + a CTA visible below that.
+- Hero flex row: stack on mobile. Any right-column visual moves below the text block with ~48px top margin.
+- Never rely on horizontal scroll. Always ensure `overflow-x: hidden` on html + body as a safety net — but don't use it as a layout solution.
+- Touch targets: minimum 44×44 CSS px. Inline nav links on mobile get expanded padding for this reason.
+- Body font size on mobile: never below 14px for primary copy. 12px is reserved for labels, metadata, captions.
+
+---
+
+## 9. Accessibility
+
+- All interactive elements have visible hover AND focus states. Don't suppress focus outlines unless you replace them with something equally visible (2px ring).
+- Decorative icons: `aria-hidden="true"`. Action icons inside buttons: keep the text label too — no icon-only buttons for primary actions.
+- Color contrast (WCAG AA): `ae-500 on ae-50`, `ae-200 on ae-900`, `white on brand-500`, `white on ae-900` all pass. If you introduce a new background, re-check body-text contrast.
+- Never convey state through color alone. "Popular" on a pricing tier is a word in a badge, not just an emerald border.
+- Respect `prefers-reduced-motion`: disable fade-ins, vertical auto-scroll, and any pulse animations.
+- Semantic HTML first. `<nav>`, `<section>`, `<article>`, `<button>`, `<details>`/`<summary>`. ARIA only when semantics aren't sufficient.
+
+---
+
+## Appendix A — Tailwind reference implementation
+
+This is what the reference site (`aerele.in`) uses. If your product uses Tailwind, you can paste these directly.
+
+### Tailwind config
+
+```js
+tailwind.config = {
+  theme: {
+    extend: {
+      colors: {
+        ae: {
+          50:'#f7f8fb',100:'#eef2fb',200:'#e4e9f5',300:'#c9d2e8',
+          400:'#94a3b8',500:'#64748b',600:'#475569',700:'#1e293b',
+          800:'#0a1a3f',900:'#060f2b',950:'#05102a',
+        },
+        brand: {
+          50:'#ecfdf5',100:'#d1fae5',200:'#a7f3d0',300:'#6ee7b7',
+          400:'#34d399',500:'#10b981',600:'#059669',700:'#047857',
+          800:'#065f46',900:'#064e3b',
+        },
+      },
+      fontFamily: {
+        sans: ['Inter','system-ui','-apple-system','sans-serif'],
+        mono: ['JetBrains Mono','ui-monospace','SFMono-Regular','Menlo','monospace'],
+      },
+    },
+  },
+};
+```
+
+### Global styles
+
+```html
+<style>
+  html { scroll-behavior: smooth; overflow-x: hidden; }
+  body { font-family: 'Inter', system-ui, sans-serif; overflow-x: hidden; }
+  .fade-in { opacity: 0; transform: translateY(16px); transition: opacity .5s ease, transform .5s ease; }
+  .fade-in.visible { opacity: 1; transform: translateY(0); }
+  .hero-glow {
+    background:
+      radial-gradient(ellipse 80% 60% at 30% 30%, rgba(16,185,129,0.08), transparent 70%),
+      radial-gradient(ellipse 60% 50% at 80% 20%, rgba(26,50,116,0.4), transparent 70%);
+  }
+</style>
+```
+
+### Nav
+
+```html
+<nav class="fixed top-0 w-full bg-white/90 backdrop-blur-md z-50 border-b border-ae-200/60">
+  <div class="max-w-7xl mx-auto px-6 sm:px-8 py-4 flex items-center justify-between">
+    <a href="/" class="flex items-center gap-2.5">
+      <img src="/logo.png" alt="..." class="h-8">
+      <span class="text-[16px] font-semibold text-ae-900 tracking-tight">Product name</span>
+    </a>
+    <div class="hidden sm:flex items-center gap-8 text-[14px] font-medium text-ae-600">
+      <a href="#" class="hover:text-ae-900 transition-colors">Link</a>
+      <a href="#" class="inline-flex items-center gap-1.5 px-4 py-2 bg-ae-900 text-white rounded-lg font-semibold hover:bg-ae-800 transition-colors">
+        Primary CTA <span aria-hidden="true">→</span>
+      </a>
+    </div>
+  </div>
+</nav>
+```
+
+### Hero
+
+```html
+<section class="relative pt-28 pb-20 sm:pt-32 sm:pb-24 overflow-hidden bg-ae-900 text-white">
+  <div class="absolute inset-0 hero-glow pointer-events-none"></div>
+  <div class="relative max-w-7xl mx-auto px-6 sm:px-8">
+    <h1 class="font-semibold tracking-tight leading-[1.15] text-white"
+        style="font-size: clamp(1.5rem, 4.4vw, 3.25rem);">
+      Plain words with <span class="text-brand-400 font-semibold">one accent</span>.
+    </h1>
+    <p class="mt-6 text-lg text-ae-200 leading-relaxed max-w-xl">Supporting paragraph.</p>
+    <div class="mt-8 flex flex-wrap gap-3">
+      <a href="#" class="inline-flex items-center gap-2 px-5 py-2.5 bg-brand-500 text-white rounded-lg text-sm font-medium hover:bg-brand-600 transition-colors">Primary →</a>
+      <a href="#" class="inline-flex items-center px-5 py-2.5 border border-white/15 text-white rounded-lg text-sm font-medium hover:bg-white/5 transition-colors">Secondary</a>
+    </div>
+  </div>
+</section>
+```
+
+### Section H2
+
+```html
+<h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950">Heading</h2>
+```
+
+### Card
+
+```html
+<div class="p-7 rounded-xl border border-ae-200/60 bg-white">
+  <h3 class="text-base font-semibold text-ae-950 mb-2">Title</h3>
+  <p class="text-sm text-ae-500 leading-relaxed">Body.</p>
+</div>
+```
+
+---
+
+## Appendix B — Plain CSS / custom-properties reference
+
+For products using vanilla CSS, CSS modules, SCSS, CSS-in-JS, or any styling approach that isn't Tailwind. Drop this in your global stylesheet and consume the variables.
+
+### Design tokens
+
+```css
+:root {
+  /* Colors — navy-slate */
+  --ae-50:  #f7f8fb;
+  --ae-100: #eef2fb;
+  --ae-200: #e4e9f5;
+  --ae-300: #c9d2e8;
+  --ae-400: #94a3b8;
+  --ae-500: #64748b;
+  --ae-600: #475569;
+  --ae-700: #1e293b;
+  --ae-800: #0a1a3f;
+  --ae-900: #060f2b;
+  --ae-950: #05102a;
+
+  /* Colors — emerald accent */
+  --brand-400: #34d399;
+  --brand-500: #10b981;
+  --brand-600: #059669;
+
+  /* Typography */
+  --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  /* Spacing (4px base) */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-7: 1.75rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+  --space-20: 5rem;
+  --space-24: 6rem;
+  --space-28: 7rem;
+  --space-32: 8rem;
+
+  /* Radii */
+  --radius-sm: 0.375rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
+  --radius-xl: 1rem;
+  --radius-full: 9999px;
+
+  /* Container */
+  --container-max: 80rem; /* 1280px */
+}
+
+html { scroll-behavior: smooth; overflow-x: hidden; }
+body {
+  font-family: var(--font-sans);
+  background: var(--ae-50);
+  color: var(--ae-900);
+  overflow-x: hidden;
+}
+
+.container {
+  max-width: var(--container-max);
+  margin-inline: auto;
+  padding-inline: var(--space-6);
+}
+@media (min-width: 640px) {
+  .container { padding-inline: var(--space-8); }
+}
+```
+
+### Example components in plain CSS
+
+```css
+/* Nav */
+.nav {
+  position: fixed; top: 0; left: 0; right: 0; z-index: 50;
+  background: rgba(255,255,255,0.9);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgb(228 233 245 / 0.6); /* ae-200 / 60 */
+}
+.nav-inner {
+  max-width: var(--container-max);
+  margin-inline: auto;
+  padding: var(--space-4) var(--space-6);
+  display: flex; align-items: center; justify-content: space-between;
+}
+.nav-cta {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: var(--space-2) var(--space-4);
+  background: var(--ae-900); color: #fff;
+  border-radius: var(--radius-md);
+  font-weight: 600; font-size: 14px;
+  transition: background-color 150ms;
+}
+.nav-cta:hover { background: var(--ae-800); }
+
+/* Hero */
+.hero {
+  position: relative; overflow: hidden;
+  background: var(--ae-900); color: #fff;
+  padding: var(--space-28) 0 var(--space-20);
+}
+.hero-glow {
+  position: absolute; inset: 0; pointer-events: none;
+  background:
+    radial-gradient(ellipse 80% 60% at 30% 30%, rgba(16,185,129,0.08), transparent 70%),
+    radial-gradient(ellipse 60% 50% at 80% 20%, rgba(26,50,116,0.4), transparent 70%);
+}
+.hero h1 {
+  font-size: clamp(1.5rem, 4.4vw, 3.25rem);
+  font-weight: 600;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  color: #fff;
+}
+.hero h1 .accent { color: var(--brand-400); }
+
+/* Section H2 */
+.section h2 {
+  font-size: 1.625rem;  /* 26px */
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+  color: var(--ae-950);
+}
+@media (min-width: 640px)  { .section h2 { font-size: 1.875rem; } } /* 30px */
+@media (min-width: 768px)  { .section h2 { font-size: 2.25rem;  } } /* 36px */
+
+/* Primary CTA */
+.btn-primary {
+  display: inline-flex; align-items: center; gap: var(--space-2);
+  padding: 10px var(--space-5);
+  background: var(--brand-500); color: #fff;
+  border-radius: var(--radius-md);
+  font-weight: 500; font-size: 14px;
+  transition: background-color 150ms;
+}
+.btn-primary:hover { background: var(--brand-600); }
+
+/* Card */
+.card {
+  padding: var(--space-7);
+  background: #fff;
+  border: 1px solid rgb(228 233 245 / 0.6);
+  border-radius: var(--radius-lg);
+}
+.card h3 {
+  font-size: 1rem; font-weight: 600; color: var(--ae-950);
+  margin-bottom: var(--space-2);
+}
+```
+
+---
+
+## Appendix C — Tokens as JSON
+
+For importing into Figma, Style Dictionary, or other design-token tools.
+
+```json
+{
+  "color": {
+    "ae": {
+      "50":  "#f7f8fb", "100": "#eef2fb", "200": "#e4e9f5", "300": "#c9d2e8",
+      "400": "#94a3b8", "500": "#64748b", "600": "#475569", "700": "#1e293b",
+      "800": "#0a1a3f", "900": "#060f2b", "950": "#05102a"
+    },
+    "brand": {
+      "50":  "#ecfdf5", "100": "#d1fae5", "200": "#a7f3d0", "300": "#6ee7b7",
+      "400": "#34d399", "500": "#10b981", "600": "#059669", "700": "#047857",
+      "800": "#065f46", "900": "#064e3b"
+    }
+  },
+  "font": {
+    "sans": "Inter, system-ui, -apple-system, sans-serif",
+    "mono": "JetBrains Mono, ui-monospace, SFMono-Regular, Menlo, monospace"
+  },
+  "fontSize": {
+    "xs": "0.75rem", "sm": "0.875rem", "base": "1rem", "lg": "1.125rem",
+    "h3": "1rem", "h2Mobile": "1.625rem", "h2Sm": "1.875rem", "h2Md": "2.25rem",
+    "h1Min": "1.5rem", "h1Max": "3.25rem", "h1Fluid": "clamp(1.5rem, 4.4vw, 3.25rem)"
+  },
+  "fontWeight": { "regular": 400, "medium": 500, "semibold": 600, "bold": 700 },
+  "lineHeight": { "tight": 1.15, "snug": 1.2, "normal": 1.4, "relaxed": 1.625 },
+  "letterSpacing": { "tight": "-0.02em", "normal": "0", "wide": "0.1em" },
+  "spacing": {
+    "1": "0.25rem",  "2": "0.5rem",  "3": "0.75rem", "4": "1rem",
+    "5": "1.25rem",  "6": "1.5rem",  "7": "1.75rem", "8": "2rem",
+    "10": "2.5rem",  "12": "3rem",   "16": "4rem",   "20": "5rem",
+    "24": "6rem",    "28": "7rem",   "32": "8rem"
+  },
+  "radius": {
+    "sm": "0.375rem", "md": "0.5rem", "lg": "0.75rem", "xl": "1rem", "full": "9999px"
+  },
+  "breakpoint": {
+    "sm": "640px", "md": "768px", "lg": "1024px", "xl": "1280px", "2xl": "1536px"
+  },
+  "container": { "max": "1280px", "paddingMobile": "1.5rem", "paddingDesktop": "2rem" }
+}
+```
+
+---
+
+## Installing this skill
+
+**As a Claude Code skill (recommended for teams using Claude Code):**
+
+Project-scoped — commit into the product repo so the whole team gets it:
+
+```
+<your-repo>/.claude/skills/aerele-design/SKILL.md
+```
+
+User-scoped — one-time install on a developer's machine, applies to every repo they work in:
+
+```
+~/.claude/skills/aerele-design/SKILL.md
+```
+
+Claude Code reads the frontmatter `description` to auto-apply the skill when a task matches. You can also invoke it explicitly with `/aerele-design`.
+
+**As plain documentation (for devs not using Claude Code):**
+
+The file is valid Markdown and stands alone. Link to it from the product's `README.md`, or paste the path into your team wiki. The tokens in §1 and the anti-patterns in §7 are the minimum a dev needs to read.
+
+---
+
+## Reference implementation
+
+`aerele.in` is the canonical implementation. When something in this doc is ambiguous, check the live site. When the live site contradicts this doc, the doc wins — the site is a snapshot, the rules are the system.

--- a/about/index.html
+++ b/about/index.html
@@ -55,38 +55,72 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico"><link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png"><link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png"><link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
-        tailwind.config = { theme: { extend: { colors: { 'ae': { 50:'#fafaf9',100:'#f0efed',200:'#e2e0dc',300:'#c8c4be',400:'#a9a49b',500:'#918b80',600:'#7a746a',700:'#5e5a52',800:'#3d3a35',900:'#1c1b18',950:'#0d0c0b' } }, fontFamily: { sans: ['Inter','system-ui','-apple-system','sans-serif'] } } } }
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        'ae': {
+                            50:  '#f7f8fb', 100: '#eef2fb', 200: '#e4e9f5', 300: '#c9d2e8',
+                            400: '#94a3b8', 500: '#64748b', 600: '#475569', 700: '#1e293b',
+                            800: '#0a1a3f', 900: '#060f2b', 950: '#05102a',
+                        },
+                        'brand': {
+                            50:  '#ecfdf5', 100: '#d1fae5', 200: '#a7f3d0', 300: '#6ee7b7',
+                            400: '#34d399', 500: '#10b981', 600: '#059669', 700: '#047857',
+                            800: '#065f46', 900: '#064e3b',
+                        }
+                    },
+                    fontFamily: {
+                        sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
+                    }
+                }
+            }
+        }
     </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" as="style">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="preload" href="/logo-nav.png" as="image">
     <style>
         html { scroll-behavior: smooth; overflow-x: hidden; }
-        body { overflow-x: hidden; font-family: 'Inter', system-ui, sans-serif; }
+        body { font-family: 'Inter', system-ui, sans-serif; overflow-x: hidden; }
+        .fade-in { opacity: 0; transform: translateY(16px); transition: opacity 0.5s ease, transform 0.5s ease; }
+        .fade-in.visible { opacity: 1; transform: translateY(0); }
+        .hero-glow { background: radial-gradient(ellipse 80% 60% at 30% 30%, rgba(16,185,129,0.08), transparent 70%), radial-gradient(ellipse 60% 50% at 80% 20%, rgba(26,50,116,0.4), transparent 70%); }
     </style>
 </head>
 <body class="bg-ae-50 text-ae-900 antialiased">
 
-    <nav class="fixed top-0 w-full bg-ae-50/80 backdrop-blur-md z-50 border-b border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
-            <a href="/" class="flex items-center gap-2.5"><img src="/logo-nav.png" alt="Aerele Technologies" class="h-8"><span class="text-[15px] font-semibold text-ae-900 tracking-tight">Aerele Technologies</span></a>
-            <div class="hidden sm:flex items-center gap-8 text-[13px] text-ae-500">
+    <nav class="fixed top-0 w-full bg-white/90 backdrop-blur-md z-50 border-b border-ae-200/60">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8 py-4 flex items-center justify-between">
+            <a href="/" class="flex items-center gap-2.5">
+                <img src="/logo-nav.png" alt="Aerele Technologies" class="h-8">
+                <span class="text-[16px] font-semibold text-ae-900 tracking-tight">Aerele Technologies</span>
+            </a>
+            <div class="hidden sm:flex items-center gap-8 text-[14px] font-medium text-ae-600">
                 <a href="/" class="hover:text-ae-900 transition-colors">Home</a>
                 <a href="/hire-frappe-developer/" class="hover:text-ae-900 transition-colors">Hire Developers</a>
                 <a href="/erpnext-customization/" class="hover:text-ae-900 transition-colors">Customization</a>
                 <a href="/erpnext-integration/" class="hover:text-ae-900 transition-colors">Integrations</a>
-                <a href="tel:+917790844832" class="px-4 py-1.5 bg-ae-900 text-ae-50 rounded-full hover:bg-ae-800 transition-colors">Get in touch</a>
+                <a href="/about/" class="hover:text-ae-900 transition-colors">About</a>
+                <a href="/hire-frappe-developer/" class="inline-flex items-center gap-1.5 px-4 py-2 bg-ae-900 text-white rounded-lg font-semibold hover:bg-ae-800 transition-colors">Hire us <span aria-hidden="true">→</span></a>
             </div>
+            <button class="sm:hidden p-2 text-ae-600" aria-label="Menu">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
+            </button>
         </div>
     </nav>
 
     <!-- Hero -->
-    <section class="pt-32 pb-16 sm:pt-44 sm:pb-24">
-        <div class="max-w-3xl mx-auto px-6">
-            <h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight leading-[1.1] mb-6">
-                We contribute to the framework <span class="text-ae-400">your business runs on</span>
+    <section class="relative pt-28 pb-20 sm:pt-32 sm:pb-24 overflow-hidden bg-ae-900 text-white">
+        <div class="absolute inset-0 hero-glow pointer-events-none"></div>
+        <div class="relative max-w-7xl mx-auto px-6 sm:px-8">
+            <h1 class="font-semibold tracking-tight leading-[1.15] text-white mb-6" style="font-size: clamp(1.5rem, 4.4vw, 3.25rem);">
+                We contribute to the framework <span class="text-brand-400 font-semibold">your business runs on</span>
             </h1>
-            <p class="text-lg text-ae-500 leading-relaxed max-w-2xl">
+            <p class="text-lg text-ae-200 leading-relaxed max-w-2xl">
                 Aerele Technologies is a software development team based in Tiruppur, Tamil Nadu. We build on the Frappe framework – and we contribute back to it. Our team has 600+ pull requests merged into ERPNext, Frappe, HRMS, Payments, and other core repositories.
             </p>
         </div>
@@ -94,7 +128,7 @@
 
     <!-- Numbers -->
     <section class="py-16 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
             <div class="grid grid-cols-2 sm:grid-cols-4 gap-8 text-center">
                 <div>
                     <p class="text-3xl font-extrabold">600+</p>
@@ -118,8 +152,8 @@
 
     <!-- Story -->
     <section class="py-20 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-8">How we got here</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-8">How we got here</h2>
 
             <div class="space-y-6 text-ae-500 leading-relaxed">
                 <p>Aerele started in 2019 in Tiruppur – a textile city in Tamil Nadu, India, not exactly the tech hub you'd expect a Frappe core development team to come from. But that's sort of the point.</p>
@@ -137,12 +171,12 @@
 
     <!-- What we do / don't do -->
     <section class="py-20 bg-ae-950 text-ae-50">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-12">What we do – and what we don't</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-white mb-12">What we do – and what we don't</h2>
 
             <div class="grid sm:grid-cols-2 gap-8">
                 <div>
-                    <h3 class="font-semibold text-lg mb-4 text-green-400">We do</h3>
+                    <h3 class="font-semibold text-lg mb-4 text-brand-400">We do</h3>
                     <ul class="space-y-3 text-sm text-ae-300">
                         <li>→ Custom Frappe app development</li>
                         <li>→ Bank API integrations (12+ Indian banks)</li>
@@ -171,8 +205,8 @@
 
     <!-- Where we contribute -->
     <section class="py-20 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-4">Repositories we contribute to</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-4">Repositories we contribute to</h2>
             <p class="text-ae-500 mb-12">Our pull requests are in public repos. You can verify every claim on this page.</p>
 
             <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
@@ -210,8 +244,8 @@
 
     <!-- Location -->
     <section class="py-20 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-4">Where we are</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-4">Where we are</h2>
             <p class="text-ae-500 leading-relaxed mb-8">Tiruppur, Tamil Nadu, India. IST (UTC+5:30). All our client engagements are remote – we integrate directly with your team's workflow over Slack, Microsoft Teams, or whatever you use. Currently serving clients across India, Oman, UAE, and Germany.</p>
 
             <div class="border border-ae-200 rounded-xl p-8">
@@ -225,19 +259,19 @@
 
     <!-- CTA -->
     <section class="py-20 bg-ae-950 text-ae-50">
-        <div class="max-w-2xl mx-auto px-6 text-center">
-            <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight mb-4">Want to work with us?</h2>
+        <div class="max-w-2xl mx-auto px-6 sm:px-8 text-center">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-white mb-4">Want to work with us?</h2>
             <p class="text-ae-400 mb-8">Tell us what you're building. We'll tell you if we're the right team – and if we're not, we'll point you to someone who is.</p>
             <div class="flex flex-wrap justify-center gap-4">
-                <a href="mailto:hello@aerele.in" class="px-8 py-3.5 bg-white text-ae-950 rounded-full text-sm font-semibold hover:bg-ae-100 transition-colors">hello@aerele.in →</a>
-                <a href="tel:+917790844832" class="px-8 py-3.5 border border-ae-700 text-ae-50 rounded-full text-sm font-semibold hover:border-ae-500 transition-colors">+91 77908 44832</a>
-                <a href="/hire-frappe-developer/" class="px-8 py-3.5 border border-ae-700 text-ae-50 rounded-full text-sm font-semibold hover:border-ae-500 transition-colors">Hire a developer →</a>
+                <a href="mailto:hello@aerele.in" class="px-8 py-3.5 bg-brand-500 text-white rounded-lg text-sm font-semibold hover:bg-brand-600 transition-colors">hello@aerele.in →</a>
+                <a href="tel:+917790844832" class="px-8 py-3.5 border border-white/15 text-ae-50 rounded-lg text-sm font-semibold hover:border-white/30 transition-colors">+91 77908 44832</a>
+                <a href="/hire-frappe-developer/" class="px-8 py-3.5 border border-white/15 text-ae-50 rounded-lg text-sm font-semibold hover:border-white/30 transition-colors">Hire a developer →</a>
             </div>
         </div>
     </section>
 
     <footer class="py-10 border-t border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6 flex flex-col sm:flex-row items-center justify-between gap-4 text-xs text-ae-400">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8 flex flex-col sm:flex-row items-center justify-between gap-4 text-xs text-ae-400">
             <p>© 2025 Aerele Technologies Pvt Ltd · Tiruppur, India</p>
             <div class="flex gap-6">
                 <a href="/" class="hover:text-ae-700">Home</a>

--- a/case-studies/alfarsi-robotics/index.html
+++ b/case-studies/alfarsi-robotics/index.html
@@ -46,52 +46,80 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico"><link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png"><link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png"><link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
-        tailwind.config = { theme: { extend: { colors: { 'ae': { 50:'#fafaf9',100:'#f0efed',200:'#e2e0dc',300:'#c8c4be',400:'#a9a49b',500:'#918b80',600:'#7a746a',700:'#5e5a52',800:'#3d3a35',900:'#1c1b18',950:'#0d0c0b' } }, fontFamily: { sans: ['Inter','system-ui','-apple-system','sans-serif'] } } } }
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        'ae': {
+                            50:  '#f7f8fb', 100: '#eef2fb', 200: '#e4e9f5', 300: '#c9d2e8',
+                            400: '#94a3b8', 500: '#64748b', 600: '#475569', 700: '#1e293b',
+                            800: '#0a1a3f', 900: '#060f2b', 950: '#05102a',
+                        },
+                        'brand': {
+                            50:  '#ecfdf5', 100: '#d1fae5', 200: '#a7f3d0', 300: '#6ee7b7',
+                            400: '#34d399', 500: '#10b981', 600: '#059669', 700: '#047857',
+                            800: '#065f46', 900: '#064e3b',
+                        }
+                    },
+                    fontFamily: {
+                        sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
+                    }
+                }
+            }
+        }
     </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" as="style">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="preload" href="/logo-nav.png" as="image">
     <style>
         html { scroll-behavior: smooth; overflow-x: hidden; }
-        body { overflow-x: hidden; font-family: 'Inter', system-ui, sans-serif; }
+        body { font-family: 'Inter', system-ui, sans-serif; overflow-x: hidden; }
+        .fade-in { opacity: 0; transform: translateY(16px); transition: opacity 0.5s ease, transform 0.5s ease; }
+        .fade-in.visible { opacity: 1; transform: translateY(0); }
+        .hero-glow { background: radial-gradient(ellipse 80% 60% at 30% 30%, rgba(16,185,129,0.08), transparent 70%), radial-gradient(ellipse 60% 50% at 80% 20%, rgba(26,50,116,0.4), transparent 70%); }
     </style>
 </head>
 <body class="bg-ae-50 text-ae-900 antialiased">
 
-    <nav class="fixed top-0 w-full bg-ae-50/80 backdrop-blur-md z-50 border-b border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
-            <a href="/" class="flex items-center gap-2.5"><img src="/logo-nav.png" alt="Aerele Technologies" class="h-8"><span class="text-[15px] font-semibold text-ae-900 tracking-tight">Aerele Technologies</span></a>
-            <div class="hidden sm:flex items-center gap-8 text-[13px] text-ae-500">
+    <nav class="fixed top-0 w-full bg-white/90 backdrop-blur-md z-50 border-b border-ae-200/60">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8 py-4 flex items-center justify-between">
+            <a href="/" class="flex items-center gap-2.5">
+                <img src="/logo-nav.png" alt="Aerele Technologies" class="h-8">
+                <span class="text-[16px] font-semibold text-ae-900 tracking-tight">Aerele Technologies</span>
+            </a>
+            <div class="hidden sm:flex items-center gap-8 text-[14px] font-medium text-ae-600">
                 <a href="/" class="hover:text-ae-900 transition-colors">Home</a>
                 <a href="/hire-frappe-developer/" class="hover:text-ae-900 transition-colors">Hire Developers</a>
+                <a href="/erpnext-customization/" class="hover:text-ae-900 transition-colors">Customization</a>
                 <a href="/erpnext-integration/" class="hover:text-ae-900 transition-colors">Integrations</a>
                 <a href="/about/" class="hover:text-ae-900 transition-colors">About</a>
-                <a href="tel:+917790844832" class="px-4 py-1.5 bg-ae-900 text-ae-50 rounded-full hover:bg-ae-800 transition-colors">Get in touch</a>
+                <a href="/hire-frappe-developer/" class="inline-flex items-center gap-1.5 px-4 py-2 bg-ae-900 text-white rounded-lg font-semibold hover:bg-ae-800 transition-colors">Hire us <span aria-hidden="true">→</span></a>
             </div>
+            <button class="sm:hidden p-2 text-ae-600" aria-label="Menu">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
+            </button>
         </div>
     </nav>
 
-    <!-- Breadcrumb -->
-    <div class="pt-24 sm:pt-28">
-        <div class="max-w-3xl mx-auto px-6">
-            <nav class="text-xs text-ae-400" aria-label="Breadcrumb">
-                <a href="/" class="hover:text-ae-700">Home</a> <span class="mx-1">→</span>
-                <span>Case Studies</span> <span class="mx-1">→</span>
-                <span class="text-ae-700">Alfarsi Robotics</span>
-            </nav>
-        </div>
-    </div>
-
     <!-- Hero -->
-    <section class="pt-8 pb-16 sm:pb-24">
-        <div class="max-w-3xl mx-auto px-6">
-            <p class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-ae-100 border border-ae-200/60 text-xs font-medium text-ae-600 mb-6">
+    <section class="relative pt-28 pb-20 sm:pt-32 sm:pb-24 overflow-hidden bg-ae-900 text-white">
+        <div class="absolute inset-0 hero-glow pointer-events-none"></div>
+        <div class="relative max-w-7xl mx-auto px-6 sm:px-8">
+            <nav class="text-xs text-ae-300 mb-6" aria-label="Breadcrumb">
+                <a href="/" class="hover:text-white">Home</a> <span class="mx-1">→</span>
+                <span>Case Studies</span> <span class="mx-1">→</span>
+                <span class="text-white">Alfarsi Robotics</span>
+            </nav>
+            <p class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-white/10 border border-white/15 text-xs font-medium text-ae-200 mb-6">
                 Alfarsi National Enterprises · Oman
             </p>
-            <h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight leading-[1.1] mb-6">
+            <h1 class="font-semibold tracking-tight leading-[1.15] text-white mb-6" style="font-size: clamp(1.5rem, 4.4vw, 3.25rem);">
                 Warehouse robotics meets ERPNext
             </h1>
-            <p class="text-xl text-ae-500 leading-relaxed max-w-2xl">
+            <p class="text-xl text-ae-200 leading-relaxed max-w-2xl">
                 How we connected a warehouse robotic system directly to ERPNext – so orders trigger conveyor belts, and returns go back to automated storage. No manual handling.
             </p>
         </div>
@@ -99,7 +127,7 @@
 
     <!-- Client context -->
     <section class="py-16 border-t border-ae-200/60 bg-ae-100/50">
-        <div class="max-w-3xl mx-auto px-6">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
             <div class="grid sm:grid-cols-3 gap-6 text-sm">
                 <div>
                     <p class="text-xs text-ae-400 uppercase tracking-wider mb-1">Client</p>
@@ -119,8 +147,8 @@
 
     <!-- The Challenge -->
     <section class="py-20 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-8">The challenge</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-8">The challenge</h2>
             <div class="space-y-4 text-ae-500 leading-relaxed">
                 <p>Alfarsi National Enterprises operates a warehouse facility in Oman with an automated robotic storage and retrieval system – conveyor belts, robotic arms, and automated rack storage. The hardware worked. The software worked. But they were separate worlds.</p>
                 <p>The warehouse robotics had its own control software. ERPNext managed orders, inventory, and accounting. Between them? Manual data entry. Someone had to look at an ERPNext Sales Order, walk to a terminal, enter the items into the warehouse system, wait for the robot to retrieve them, then walk back to ERPNext and update the delivery status.</p>
@@ -131,8 +159,8 @@
 
     <!-- What we built -->
     <section class="py-20 bg-ae-950 text-ae-50">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-8">What we built</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-white mb-8">What we built</h2>
 
             <div class="space-y-8">
                 <div>
@@ -160,8 +188,8 @@
 
     <!-- The flow -->
     <section class="py-20 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-12">How it works</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-12">How it works</h2>
 
             <div class="space-y-8">
                 <div class="flex gap-4">
@@ -198,8 +226,8 @@
 
     <!-- Results -->
     <section class="py-20 border-t border-ae-200/60 bg-ae-100/50">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-8">Results</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-8">Results</h2>
             <div class="grid sm:grid-cols-3 gap-6">
                 <div class="border border-ae-200 rounded-lg p-6 bg-white text-center">
                     <p class="text-2xl font-extrabold">Zero</p>
@@ -219,8 +247,8 @@
 
     <!-- Why this matters -->
     <section class="py-20 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-8">Why this matters for ERPNext</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-8">Why this matters for ERPNext</h2>
             <div class="space-y-4 text-ae-500 leading-relaxed">
                 <p>This project demonstrates that ERPNext isn't just for accounting and order management. With the right integration work, it can be the central nervous system for physical operations – including robotics and automated hardware.</p>
                 <p>The Frappe framework's REST API, webhook system, and background job infrastructure made it possible to build a real-time integration between ERPNext and warehouse robotics. No middleware. No third-party integration platforms. Just Frappe talking to hardware.</p>
@@ -231,15 +259,15 @@
 
     <!-- CTA -->
     <section class="py-20 bg-ae-950 text-ae-50">
-        <div class="max-w-2xl mx-auto px-6 text-center">
-            <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight mb-4">Building something that connects to ERPNext?</h2>
+        <div class="max-w-2xl mx-auto px-6 sm:px-8 text-center">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-white mb-4">Building something that connects to ERPNext?</h2>
             <p class="text-ae-400 mb-8">Warehouse system, manufacturing equipment, IoT sensors, or any hardware – if it has an API, we can connect it to ERPNext.</p>
-            <a href="mailto:hello@aerele.in" class="inline-block px-8 py-3.5 bg-white text-ae-950 rounded-full text-sm font-semibold hover:bg-ae-100 transition-colors">hello@aerele.in →</a>
+            <a href="mailto:hello@aerele.in" class="inline-block px-8 py-3.5 bg-brand-500 text-white rounded-lg text-sm font-semibold hover:bg-brand-600 transition-colors">hello@aerele.in →</a>
         </div>
     </section>
 
     <footer class="py-10 border-t border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6 flex flex-col sm:flex-row items-center justify-between gap-4 text-xs text-ae-400">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8 flex flex-col sm:flex-row items-center justify-between gap-4 text-xs text-ae-400">
             <p>© 2025 Aerele Technologies Pvt Ltd · Tiruppur, India</p>
             <div class="flex gap-6">
                 <a href="/" class="hover:text-ae-700">Home</a>

--- a/case-studies/india-banking/index.html
+++ b/case-studies/india-banking/index.html
@@ -46,65 +46,93 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico"><link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png"><link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png"><link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
-        tailwind.config = { theme: { extend: { colors: { 'ae': { 50:'#fafaf9',100:'#f0efed',200:'#e2e0dc',300:'#c8c4be',400:'#a9a49b',500:'#918b80',600:'#7a746a',700:'#5e5a52',800:'#3d3a35',900:'#1c1b18',950:'#0d0c0b' } }, fontFamily: { sans: ['Inter','system-ui','-apple-system','sans-serif'] } } } }
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        'ae': {
+                            50:  '#f7f8fb', 100: '#eef2fb', 200: '#e4e9f5', 300: '#c9d2e8',
+                            400: '#94a3b8', 500: '#64748b', 600: '#475569', 700: '#1e293b',
+                            800: '#0a1a3f', 900: '#060f2b', 950: '#05102a',
+                        },
+                        'brand': {
+                            50:  '#ecfdf5', 100: '#d1fae5', 200: '#a7f3d0', 300: '#6ee7b7',
+                            400: '#34d399', 500: '#10b981', 600: '#059669', 700: '#047857',
+                            800: '#065f46', 900: '#064e3b',
+                        }
+                    },
+                    fontFamily: {
+                        sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
+                    }
+                }
+            }
+        }
     </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" as="style">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="preload" href="/logo-nav.png" as="image">
     <style>
         html { scroll-behavior: smooth; overflow-x: hidden; }
-        body { overflow-x: hidden; font-family: 'Inter', system-ui, sans-serif; }
+        body { font-family: 'Inter', system-ui, sans-serif; overflow-x: hidden; }
+        .fade-in { opacity: 0; transform: translateY(16px); transition: opacity 0.5s ease, transform 0.5s ease; }
+        .fade-in.visible { opacity: 1; transform: translateY(0); }
+        .hero-glow { background: radial-gradient(ellipse 80% 60% at 30% 30%, rgba(16,185,129,0.08), transparent 70%), radial-gradient(ellipse 60% 50% at 80% 20%, rgba(26,50,116,0.4), transparent 70%); }
     </style>
 </head>
 <body class="bg-ae-50 text-ae-900 antialiased">
 
-    <nav class="fixed top-0 w-full bg-ae-50/80 backdrop-blur-md z-50 border-b border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
-            <a href="/" class="flex items-center gap-2.5"><img src="/logo-nav.png" alt="Aerele Technologies" class="h-8"><span class="text-[15px] font-semibold text-ae-900 tracking-tight">Aerele Technologies</span></a>
-            <div class="hidden sm:flex items-center gap-8 text-[13px] text-ae-500">
+    <nav class="fixed top-0 w-full bg-white/90 backdrop-blur-md z-50 border-b border-ae-200/60">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8 py-4 flex items-center justify-between">
+            <a href="/" class="flex items-center gap-2.5">
+                <img src="/logo-nav.png" alt="Aerele Technologies" class="h-8">
+                <span class="text-[16px] font-semibold text-ae-900 tracking-tight">Aerele Technologies</span>
+            </a>
+            <div class="hidden sm:flex items-center gap-8 text-[14px] font-medium text-ae-600">
                 <a href="/" class="hover:text-ae-900 transition-colors">Home</a>
                 <a href="/hire-frappe-developer/" class="hover:text-ae-900 transition-colors">Hire Developers</a>
+                <a href="/erpnext-customization/" class="hover:text-ae-900 transition-colors">Customization</a>
                 <a href="/erpnext-integration/" class="hover:text-ae-900 transition-colors">Integrations</a>
                 <a href="/about/" class="hover:text-ae-900 transition-colors">About</a>
-                <a href="tel:+917790844832" class="px-4 py-1.5 bg-ae-900 text-ae-50 rounded-full hover:bg-ae-800 transition-colors">Get in touch</a>
+                <a href="/hire-frappe-developer/" class="inline-flex items-center gap-1.5 px-4 py-2 bg-ae-900 text-white rounded-lg font-semibold hover:bg-ae-800 transition-colors">Hire us <span aria-hidden="true">→</span></a>
             </div>
+            <button class="sm:hidden p-2 text-ae-600" aria-label="Menu">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
+            </button>
         </div>
     </nav>
 
-    <!-- Breadcrumb -->
-    <div class="pt-24 sm:pt-28">
-        <div class="max-w-3xl mx-auto px-6">
-            <nav class="text-xs text-ae-400" aria-label="Breadcrumb">
-                <a href="/" class="hover:text-ae-700">Home</a> <span class="mx-1">→</span>
-                <span>Case Studies</span> <span class="mx-1">→</span>
-                <span class="text-ae-700">India Banking Suite</span>
-            </nav>
-        </div>
-    </div>
-
     <!-- Hero -->
-    <section class="pt-8 pb-16 sm:pb-24">
-        <div class="max-w-3xl mx-auto px-6">
-            <p class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-ae-100 border border-ae-200/60 text-xs font-medium text-ae-600 mb-6">
+    <section class="relative pt-28 pb-20 sm:pt-32 sm:pb-24 overflow-hidden bg-ae-900 text-white">
+        <div class="absolute inset-0 hero-glow pointer-events-none"></div>
+        <div class="relative max-w-7xl mx-auto px-6 sm:px-8">
+            <nav class="text-xs text-ae-300 mb-6" aria-label="Breadcrumb">
+                <a href="/" class="hover:text-white">Home</a> <span class="mx-1">→</span>
+                <span>Case Studies</span> <span class="mx-1">→</span>
+                <span class="text-white">India Banking Suite</span>
+            </nav>
+            <p class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-white/10 border border-white/15 text-xs font-medium text-ae-200 mb-6">
                 Open Source · 31+ ⭐ · 43+ forks
             </p>
-            <h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight leading-[1.1] mb-6">
+            <h1 class="font-semibold tracking-tight leading-[1.15] text-white mb-6" style="font-size: clamp(1.5rem, 4.4vw, 3.25rem);">
                 India Banking Suite
             </h1>
-            <p class="text-xl text-ae-500 leading-relaxed max-w-2xl mb-8">
+            <p class="text-xl text-ae-200 leading-relaxed max-w-2xl mb-8">
                 ERPNext integration with 12+ Indian banks. Vendor payouts, payroll disbursement, and bank statement reconciliation – all from within ERPNext.
             </p>
             <div class="flex flex-wrap gap-4">
-                <a href="https://github.com/aerele/india-banking" class="px-6 py-3 bg-ae-900 text-ae-50 rounded-full text-sm font-medium hover:bg-ae-800 transition-colors">View on GitHub →</a>
-                <a href="mailto:hello@aerele.in" class="px-6 py-3 border border-ae-300 text-ae-700 rounded-full text-sm font-medium hover:border-ae-400 transition-colors">Deploy for your business →</a>
+                <a href="https://github.com/aerele/india-banking" class="px-6 py-3 bg-brand-500 hover:bg-brand-600 text-white rounded-lg text-sm font-medium transition-colors">View on GitHub →</a>
+                <a href="mailto:hello@aerele.in" class="px-6 py-3 border border-white/15 text-white rounded-lg text-sm font-medium hover:border-white/30 transition-colors">Deploy for your business →</a>
             </div>
         </div>
     </section>
 
     <!-- The Problem -->
     <section class="py-20 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-8">The problem</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-8">The problem</h2>
             <div class="space-y-4 text-ae-500 leading-relaxed">
                 <p>Indian businesses running ERPNext had a painful gap: the ERP tracked what they owed vendors and employees, but actually paying them required logging into bank portals, manually entering details, uploading CSV files, and then reconciling statements back into ERPNext.</p>
                 <p>For companies with multiple entities and bank accounts across different banks, this meant hours of daily manual work, data entry errors, failed payments from typos, and reconciliation that was always behind.</p>
@@ -115,8 +143,8 @@
 
     <!-- The Solution -->
     <section class="py-20 bg-ae-950 text-ae-50">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-8">What we built</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-white mb-8">What we built</h2>
 
             <div class="space-y-8">
                 <div>
@@ -158,8 +186,8 @@
 
     <!-- Scale -->
     <section class="py-20 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-8">Enterprise scale</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-8">Enterprise scale</h2>
             <div class="space-y-4 text-ae-500 leading-relaxed">
                 <p>The india-banking suite is deployed at enterprise scale – multiple banks with multiple accounts running in a single multi-company ERPNext site. Built on standard <strong class="text-ae-900">Payment Request</strong> and <strong class="text-ae-900">Payment Order</strong> doctypes – fully upgrade-friendly. Numerous companies run their entire banking operations through this single integration. <a href="https://frappe.io/incubator/project/India%20Banking" target="_blank" rel="noopener" class="underline text-ae-700">Under Frappe's Incubation Program →</a></p>
                 <p>The app is designed for multi-company setups from day one. Each entity can have different banks, different approval workflows, and different payment preferences. The unified interface means finance teams don't need to learn multiple bank portals.</p>
@@ -184,8 +212,8 @@
 
     <!-- Technical architecture -->
     <section class="py-20 border-t border-ae-200/60 bg-ae-100/50">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-8">Technical architecture</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-8">Technical architecture</h2>
             <div class="space-y-4 text-ae-500 leading-relaxed text-sm">
                 <p><strong class="text-ae-700">Framework:</strong> Frappe framework (Python backend, JS frontend)</p>
                 <p><strong class="text-ae-700">Bank communication:</strong> REST APIs (ICICI, YES Bank, Kotak), SOAP/XML (HDFC), SFTP file exchange (H2H mode)</p>
@@ -199,11 +227,11 @@
 
     <!-- Open source -->
     <section class="py-20 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6 text-center">
-            <h2 class="text-2xl font-bold mb-4">This is open source</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8 text-center">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-4">This is open source</h2>
             <p class="text-ae-500 mb-8 max-w-xl mx-auto">The entire india-banking suite is MIT licensed and available on GitHub. Read the code, deploy it yourself, or hire us to set it up and maintain it for your business.</p>
             <div class="flex flex-wrap justify-center gap-4">
-                <a href="https://github.com/aerele/india-banking" class="px-5 py-2.5 bg-ae-900 text-ae-50 rounded-full text-sm font-medium hover:bg-ae-800 transition-colors">india-banking · 31 ⭐</a>
+                <a href="https://github.com/aerele/india-banking" class="px-5 py-2.5 bg-brand-500 text-white rounded-lg text-sm font-medium hover:bg-brand-600 transition-colors">india-banking · 31 ⭐</a>
                 <a href="https://github.com/aerele/india-banking-connector" class="px-5 py-2.5 border border-ae-300 text-ae-700 rounded-full text-sm font-medium hover:border-ae-400 transition-colors">india-banking-connector</a>
                 <a href="https://github.com/aerele/india-banking-h2h" class="px-5 py-2.5 border border-ae-300 text-ae-700 rounded-full text-sm font-medium hover:border-ae-400 transition-colors">india-banking-h2h</a>
             </div>
@@ -212,15 +240,15 @@
 
     <!-- CTA -->
     <section class="py-20 bg-ae-950 text-ae-50">
-        <div class="max-w-2xl mx-auto px-6 text-center">
-            <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight mb-4">Need bank integration for your ERPNext?</h2>
+        <div class="max-w-2xl mx-auto px-6 sm:px-8 text-center">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-white mb-4">Need bank integration for your ERPNext?</h2>
             <p class="text-ae-400 mb-8">Whether you want to deploy india-banking, add a new bank connector, or build a custom integration – we're the team that built it.</p>
-            <a href="mailto:hello@aerele.in" class="inline-block px-8 py-3.5 bg-white text-ae-950 rounded-full text-sm font-semibold hover:bg-ae-100 transition-colors">hello@aerele.in →</a>
+            <a href="mailto:hello@aerele.in" class="inline-block px-8 py-3.5 bg-brand-500 text-white rounded-lg text-sm font-semibold hover:bg-brand-600 transition-colors">hello@aerele.in →</a>
         </div>
     </section>
 
     <footer class="py-10 border-t border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6 flex flex-col sm:flex-row items-center justify-between gap-4 text-xs text-ae-400">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8 flex flex-col sm:flex-row items-center justify-between gap-4 text-xs text-ae-400">
             <p>© 2025 Aerele Technologies Pvt Ltd · Tiruppur, India</p>
             <div class="flex gap-6">
                 <a href="/" class="hover:text-ae-700">Home</a>

--- a/dpa/index.html
+++ b/dpa/index.html
@@ -37,47 +37,73 @@
                 extend: {
                     colors: {
                         'ae': {
-                            50: '#fafaf9', 100: '#f0efed', 200: '#e2e0dc', 300: '#c8c4be',
-                            400: '#a9a49b', 500: '#918b80', 600: '#7a746a', 700: '#5e5a52',
-                            800: '#3d3a35', 900: '#1c1b18', 950: '#0d0c0b',
+                            50:  '#f7f8fb', 100: '#eef2fb', 200: '#e4e9f5', 300: '#c9d2e8',
+                            400: '#94a3b8', 500: '#64748b', 600: '#475569', 700: '#1e293b',
+                            800: '#0a1a3f', 900: '#060f2b', 950: '#05102a',
+                        },
+                        'brand': {
+                            50:  '#ecfdf5', 100: '#d1fae5', 200: '#a7f3d0', 300: '#6ee7b7',
+                            400: '#34d399', 500: '#10b981', 600: '#059669', 700: '#047857',
+                            800: '#065f46', 900: '#064e3b',
                         }
                     },
-                    fontFamily: { sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'] }
+                    fontFamily: {
+                        sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
+                    }
                 }
             }
         }
     </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-    <style>html{scroll-behavior:smooth;overflow-x:hidden}body{overflow-x:hidden;font-family:'Inter',system-ui,sans-serif}</style>
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" as="style">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="preload" href="/logo-nav.png" as="image">
+    <style>
+        html { scroll-behavior: smooth; overflow-x: hidden; }
+        body { font-family: 'Inter', system-ui, sans-serif; overflow-x: hidden; }
+        .fade-in { opacity: 0; transform: translateY(16px); transition: opacity 0.5s ease, transform 0.5s ease; }
+        .fade-in.visible { opacity: 1; transform: translateY(0); }
+        .hero-glow { background: radial-gradient(ellipse 80% 60% at 30% 30%, rgba(16,185,129,0.08), transparent 70%), radial-gradient(ellipse 60% 50% at 80% 20%, rgba(26,50,116,0.4), transparent 70%); }
+    </style>
 </head>
 <body class="bg-ae-50 text-ae-900 antialiased">
 
-    <nav class="fixed top-0 w-full bg-ae-50/80 backdrop-blur-md z-50 border-b border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
-            <a href="/" class="flex items-center gap-2.5"><img src="/logo-nav.png" alt="Aerele Technologies" class="h-8"><span class="text-[15px] font-semibold text-ae-900 tracking-tight">Aerele Technologies</span></a>
-            <div class="hidden sm:flex items-center gap-8 text-[13px] text-ae-500">
-                <a href="/" class="hover:text-ae-900">Home</a>
-                <a href="/about/" class="hover:text-ae-900">About</a>
-                <a href="tel:+917790844832" class="px-4 py-1.5 bg-ae-900 text-ae-50 rounded-full hover:bg-ae-800">Get in touch</a>
+    <nav class="fixed top-0 w-full bg-white/90 backdrop-blur-md z-50 border-b border-ae-200/60">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8 py-4 flex items-center justify-between">
+            <a href="/" class="flex items-center gap-2.5">
+                <img src="/logo-nav.png" alt="Aerele Technologies" class="h-8">
+                <span class="text-[16px] font-semibold text-ae-900 tracking-tight">Aerele Technologies</span>
+            </a>
+            <div class="hidden sm:flex items-center gap-8 text-[14px] font-medium text-ae-600">
+                <a href="/" class="hover:text-ae-900 transition-colors">Home</a>
+                <a href="/hire-frappe-developer/" class="hover:text-ae-900 transition-colors">Hire Developers</a>
+                <a href="/erpnext-customization/" class="hover:text-ae-900 transition-colors">Customization</a>
+                <a href="/erpnext-integration/" class="hover:text-ae-900 transition-colors">Integrations</a>
+                <a href="/about/" class="hover:text-ae-900 transition-colors">About</a>
+                <a href="/hire-frappe-developer/" class="inline-flex items-center gap-1.5 px-4 py-2 bg-ae-900 text-white rounded-lg font-semibold hover:bg-ae-800 transition-colors">Hire us <span aria-hidden="true">→</span></a>
             </div>
+            <button class="sm:hidden p-2 text-ae-600" aria-label="Menu">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
+            </button>
         </div>
     </nav>
 
-    <section class="pt-32 pb-8">
-        <div class="max-w-3xl mx-auto px-6">
-            <p class="text-xs text-ae-400 mb-4"><a href="/" class="hover:text-ae-700">Aerele</a> → Data Processing Agreement</p>
-            <h1 class="text-3xl sm:text-4xl font-extrabold tracking-tight mb-4">Data Processing Agreement</h1>
-            <p class="text-sm text-ae-400">Last updated: March 12, 2025</p>
-            <div class="mt-4 p-4 bg-ae-100 rounded-lg border border-ae-200/60">
-                <p class="text-xs text-ae-500">This DPA is entered into by and between the entity agreeing to these terms as the data controller ("Controller") and Aerele Technologies Pvt Ltd as the data processor ("Processor"). This DPA supplements and forms part of any service agreement between the parties.</p>
+    <section class="relative pt-28 pb-20 sm:pt-32 sm:pb-24 overflow-hidden bg-ae-900 text-white">
+        <div class="absolute inset-0 hero-glow pointer-events-none"></div>
+        <div class="relative max-w-7xl mx-auto px-6 sm:px-8">
+            <p class="text-xs text-ae-300 mb-4"><a href="/" class="hover:text-white">Aerele</a> → Data Processing Agreement</p>
+            <h1 class="font-semibold tracking-tight leading-[1.15] text-white mb-4" style="font-size: clamp(1.5rem, 4.4vw, 3.25rem);">Data Processing Agreement</h1>
+            <p class="text-sm text-ae-300">Last updated: March 12, 2025</p>
+            <div class="mt-4 p-4 bg-white/5 rounded-lg border border-white/10">
+                <p class="text-xs text-ae-200">This DPA is entered into by and between the entity agreeing to these terms as the data controller ("Controller") and Aerele Technologies Pvt Ltd as the data processor ("Processor"). This DPA supplements and forms part of any service agreement between the parties.</p>
             </div>
         </div>
     </section>
 
-    <section class="pb-20">
-        <div class="max-w-3xl mx-auto px-6">
+    <section class="pb-20 pt-16">
+        <div class="max-w-3xl mx-auto px-6 sm:px-8">
             <div class="space-y-8 text-sm text-ae-600 leading-relaxed">
 
                 <div>
@@ -234,7 +260,7 @@
     </section>
 
     <footer class="py-10 border-t border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
             <div class="flex flex-col sm:flex-row items-center justify-between gap-3">
                 <p class="text-xs text-ae-400">© 2025 Aerele Technologies Pvt Ltd · Tiruppur, India</p>
                 <div class="flex gap-6 text-xs text-ae-400">

--- a/erpnext-customization/index.html
+++ b/erpnext-customization/index.html
@@ -43,54 +43,86 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico"><link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png"><link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png"><link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
-        tailwind.config = { theme: { extend: { colors: { 'ae': { 50:'#fafaf9',100:'#f0efed',200:'#e2e0dc',300:'#c8c4be',400:'#a9a49b',500:'#918b80',600:'#7a746a',700:'#5e5a52',800:'#3d3a35',900:'#1c1b18',950:'#0d0c0b' } }, fontFamily: { sans: ['Inter','system-ui','-apple-system','sans-serif'] } } } }
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        'ae': {
+                            50:  '#f7f8fb', 100: '#eef2fb', 200: '#e4e9f5', 300: '#c9d2e8',
+                            400: '#94a3b8', 500: '#64748b', 600: '#475569', 700: '#1e293b',
+                            800: '#0a1a3f', 900: '#060f2b', 950: '#05102a',
+                        },
+                        'brand': {
+                            50:  '#ecfdf5', 100: '#d1fae5', 200: '#a7f3d0', 300: '#6ee7b7',
+                            400: '#34d399', 500: '#10b981', 600: '#059669', 700: '#047857',
+                            800: '#065f46', 900: '#064e3b',
+                        }
+                    },
+                    fontFamily: {
+                        sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
+                    }
+                }
+            }
+        }
     </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" as="style">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="preload" href="/logo-nav.png" as="image">
     <style>
         html { scroll-behavior: smooth; overflow-x: hidden; }
-        body { overflow-x: hidden; font-family: 'Inter', system-ui, sans-serif; }
+        body { font-family: 'Inter', system-ui, sans-serif; overflow-x: hidden; }
         .fade-in { opacity: 0; transform: translateY(16px); transition: opacity 0.5s ease, transform 0.5s ease; }
         .fade-in.visible { opacity: 1; transform: translateY(0); }
+        .hero-glow { background: radial-gradient(ellipse 80% 60% at 30% 30%, rgba(16,185,129,0.08), transparent 70%), radial-gradient(ellipse 60% 50% at 80% 20%, rgba(26,50,116,0.4), transparent 70%); }
     </style>
 </head>
 <body class="bg-ae-50 text-ae-900 antialiased">
 
-    <nav class="fixed top-0 w-full bg-ae-50/80 backdrop-blur-md z-50 border-b border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
-            <a href="/" class="flex items-center gap-2.5"><img src="/logo-nav.png" alt="Aerele Technologies" class="h-8"><span class="text-[15px] font-semibold text-ae-900 tracking-tight">Aerele Technologies</span></a>
-            <div class="hidden sm:flex items-center gap-8 text-[13px] text-ae-500">
+    <nav class="fixed top-0 w-full bg-white/90 backdrop-blur-md z-50 border-b border-ae-200/60">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8 py-4 flex items-center justify-between">
+            <a href="/" class="flex items-center gap-2.5">
+                <img src="/logo-nav.png" alt="Aerele Technologies" class="h-8">
+                <span class="text-[16px] font-semibold text-ae-900 tracking-tight">Aerele Technologies</span>
+            </a>
+            <div class="hidden sm:flex items-center gap-8 text-[14px] font-medium text-ae-600">
                 <a href="/" class="hover:text-ae-900 transition-colors">Home</a>
                 <a href="/hire-frappe-developer/" class="hover:text-ae-900 transition-colors">Hire Developers</a>
+                <a href="/erpnext-customization/" class="hover:text-ae-900 transition-colors">Customization</a>
                 <a href="/erpnext-integration/" class="hover:text-ae-900 transition-colors">Integrations</a>
                 <a href="/about/" class="hover:text-ae-900 transition-colors">About</a>
-                <a href="tel:+917790844832" class="px-4 py-1.5 bg-ae-900 text-ae-50 rounded-full hover:bg-ae-800 transition-colors">Get in touch</a>
+                <a href="/hire-frappe-developer/" class="inline-flex items-center gap-1.5 px-4 py-2 bg-ae-900 text-white rounded-lg font-semibold hover:bg-ae-800 transition-colors">Hire us <span aria-hidden="true">→</span></a>
             </div>
+            <button class="sm:hidden p-2 text-ae-600" aria-label="Menu">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
+            </button>
         </div>
     </nav>
 
     <!-- Hero -->
-    <section class="pt-32 pb-16 sm:pt-44 sm:pb-24">
-        <div class="max-w-3xl mx-auto px-6">
-            <p class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-ae-100 border border-ae-200/60 text-xs font-medium text-ae-600 mb-6">
-                <span class="w-1.5 h-1.5 rounded-full bg-green-500"></span>
+    <section class="relative pt-28 pb-20 sm:pt-32 sm:pb-24 overflow-hidden bg-ae-900 text-white">
+        <div class="absolute inset-0 hero-glow pointer-events-none"></div>
+        <div class="relative max-w-7xl mx-auto px-6 sm:px-8">
+            <p class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-white/10 border border-white/15 text-xs font-medium text-ae-200 mb-6">
+                <span class="w-1.5 h-1.5 rounded-full bg-brand-500 animate-pulse"></span>
                 Built by Frappe core contributors
             </p>
-            <h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight leading-[1.1] mb-6">
-                ERPNext customization by developers who <span class="text-ae-400">know the framework from the inside</span>
+            <h1 class="font-semibold tracking-tight leading-[1.15] text-white mb-6" style="font-size: clamp(1.5rem, 4.4vw, 3.25rem);">
+                ERPNext customization by developers who <span class="text-brand-400 font-semibold">know the framework from the inside</span>
             </h1>
-            <p class="text-lg text-ae-500 leading-relaxed max-w-2xl mb-8">
+            <p class="text-lg text-ae-200 leading-relaxed max-w-2xl mb-8">
                 Every ERPNext customization we build is informed by our experience contributing to the Frappe framework itself. We don't work around the framework – we work with it. That means cleaner code, fewer upgrade-breaking changes, and customizations that survive version updates.
             </p>
-            <a href="mailto:hello@aerele.in" class="inline-block px-6 py-3 bg-ae-900 text-ae-50 rounded-full text-sm font-medium hover:bg-ae-800 transition-colors">Discuss your customization →</a>
+            <a href="mailto:hello@aerele.in" class="inline-block px-6 py-3 bg-brand-500 hover:bg-brand-600 text-white rounded-lg text-sm font-medium transition-colors">Discuss your customization →</a>
         </div>
     </section>
 
     <!-- What we customize -->
     <section class="py-20 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-12">What we build on ERPNext</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-12">What we build on ERPNext</h2>
 
             <div class="space-y-10">
                 <div>
@@ -127,8 +159,8 @@
 
     <!-- Why customization from contributors is different -->
     <section class="py-20 bg-ae-950 text-ae-50">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-12">Why contributor-built customizations are different</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-white mb-12">Why contributor-built customizations are different</h2>
 
             <div class="grid sm:grid-cols-2 gap-8">
                 <div class="bg-ae-900/50 rounded-lg p-6 border border-ae-800/50">
@@ -153,8 +185,8 @@
 
     <!-- Industries -->
     <section class="py-20 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-12">Industries we've customized ERPNext for</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-12">Industries we've customized ERPNext for</h2>
             <div class="grid grid-cols-2 sm:grid-cols-3 gap-6 text-sm">
                 <div class="border border-ae-200 rounded-lg p-5">
                     <p class="font-semibold mb-1">Banking & Finance</p>
@@ -186,7 +218,7 @@
 
     <!-- Related services -->
     <section class="py-16 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
             <h2 class="text-xl font-bold mb-8">Related services</h2>
             <div class="grid sm:grid-cols-3 gap-4">
                 <a href="/hire-frappe-developer/" class="border border-ae-200 rounded-lg p-5 hover:border-ae-400 transition-colors">
@@ -207,8 +239,8 @@
 
     <!-- FAQ -->
     <section class="py-20 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl font-bold tracking-tight mb-12">Frequently asked questions about ERPNext customization</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-12">Frequently asked questions about ERPNext customization</h2>
             <div class="space-y-6">
                 <details class="group" open>
                     <summary class="flex items-center justify-between cursor-pointer py-4 border-b border-ae-200/60 text-sm font-semibold text-ae-900">
@@ -237,15 +269,15 @@
 
     <!-- CTA -->
     <section class="py-20 bg-ae-950 text-ae-50">
-        <div class="max-w-2xl mx-auto px-6 text-center">
-            <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight mb-4">Need ERPNext customized?</h2>
+        <div class="max-w-2xl mx-auto px-6 sm:px-8 text-center">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-white mb-4">Need ERPNext customized?</h2>
             <p class="text-ae-400 mb-8">Tell us the problem. We'll tell you whether it needs a custom app, a workflow, or just a better configuration – and we'll be honest about which.</p>
-            <a href="mailto:hello@aerele.in" class="inline-block px-8 py-3.5 bg-white text-ae-950 rounded-full text-sm font-semibold hover:bg-ae-100 transition-colors">hello@aerele.in →</a>
+            <a href="mailto:hello@aerele.in" class="inline-block px-8 py-3.5 bg-brand-500 text-white rounded-lg text-sm font-semibold hover:bg-brand-600 transition-colors">hello@aerele.in →</a>
         </div>
     </section>
 
     <footer class="py-10 border-t border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6 flex flex-col sm:flex-row items-center justify-between gap-4 text-xs text-ae-400">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8 flex flex-col sm:flex-row items-center justify-between gap-4 text-xs text-ae-400">
             <p>© 2025 Aerele Technologies Pvt Ltd · Tiruppur, India</p>
             <div class="flex gap-6">
                 <a href="/" class="hover:text-ae-700">Home</a>

--- a/erpnext-integration/index.html
+++ b/erpnext-integration/index.html
@@ -43,55 +43,89 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico"><link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png"><link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png"><link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
-        tailwind.config = { theme: { extend: { colors: { 'ae': { 50:'#fafaf9',100:'#f0efed',200:'#e2e0dc',300:'#c8c4be',400:'#a9a49b',500:'#918b80',600:'#7a746a',700:'#5e5a52',800:'#3d3a35',900:'#1c1b18',950:'#0d0c0b' } }, fontFamily: { sans: ['Inter','system-ui','-apple-system','sans-serif'] } } } }
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        'ae': {
+                            50:  '#f7f8fb', 100: '#eef2fb', 200: '#e4e9f5', 300: '#c9d2e8',
+                            400: '#94a3b8', 500: '#64748b', 600: '#475569', 700: '#1e293b',
+                            800: '#0a1a3f', 900: '#060f2b', 950: '#05102a',
+                        },
+                        'brand': {
+                            50:  '#ecfdf5', 100: '#d1fae5', 200: '#a7f3d0', 300: '#6ee7b7',
+                            400: '#34d399', 500: '#10b981', 600: '#059669', 700: '#047857',
+                            800: '#065f46', 900: '#064e3b',
+                        }
+                    },
+                    fontFamily: {
+                        sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
+                    }
+                }
+            }
+        }
     </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" as="style">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="preload" href="/logo-nav.png" as="image">
     <style>
         html { scroll-behavior: smooth; overflow-x: hidden; }
-        body { overflow-x: hidden; font-family: 'Inter', system-ui, sans-serif; }
+        body { font-family: 'Inter', system-ui, sans-serif; overflow-x: hidden; }
+        .fade-in { opacity: 0; transform: translateY(16px); transition: opacity 0.5s ease, transform 0.5s ease; }
+        .fade-in.visible { opacity: 1; transform: translateY(0); }
+        .hero-glow { background: radial-gradient(ellipse 80% 60% at 30% 30%, rgba(16,185,129,0.08), transparent 70%), radial-gradient(ellipse 60% 50% at 80% 20%, rgba(26,50,116,0.4), transparent 70%); }
     </style>
 </head>
 <body class="bg-ae-50 text-ae-900 antialiased">
 
-    <nav class="fixed top-0 w-full bg-ae-50/80 backdrop-blur-md z-50 border-b border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
-            <a href="/" class="flex items-center gap-2.5"><img src="/logo-nav.png" alt="Aerele Technologies" class="h-8"><span class="text-[15px] font-semibold text-ae-900 tracking-tight">Aerele Technologies</span></a>
-            <div class="hidden sm:flex items-center gap-8 text-[13px] text-ae-500">
+    <nav class="fixed top-0 w-full bg-white/90 backdrop-blur-md z-50 border-b border-ae-200/60">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8 py-4 flex items-center justify-between">
+            <a href="/" class="flex items-center gap-2.5">
+                <img src="/logo-nav.png" alt="Aerele Technologies" class="h-8">
+                <span class="text-[16px] font-semibold text-ae-900 tracking-tight">Aerele Technologies</span>
+            </a>
+            <div class="hidden sm:flex items-center gap-8 text-[14px] font-medium text-ae-600">
                 <a href="/" class="hover:text-ae-900 transition-colors">Home</a>
                 <a href="/hire-frappe-developer/" class="hover:text-ae-900 transition-colors">Hire Developers</a>
                 <a href="/erpnext-customization/" class="hover:text-ae-900 transition-colors">Customization</a>
+                <a href="/erpnext-integration/" class="hover:text-ae-900 transition-colors">Integrations</a>
                 <a href="/about/" class="hover:text-ae-900 transition-colors">About</a>
-                <a href="tel:+917790844832" class="px-4 py-1.5 bg-ae-900 text-ae-50 rounded-full hover:bg-ae-800 transition-colors">Get in touch</a>
+                <a href="/hire-frappe-developer/" class="inline-flex items-center gap-1.5 px-4 py-2 bg-ae-900 text-white rounded-lg font-semibold hover:bg-ae-800 transition-colors">Hire us <span aria-hidden="true">→</span></a>
             </div>
+            <button class="sm:hidden p-2 text-ae-600" aria-label="Menu">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
+            </button>
         </div>
     </nav>
 
     <!-- Hero -->
-    <section class="pt-32 pb-16 sm:pt-44 sm:pb-24">
-        <div class="max-w-3xl mx-auto px-6">
-            <p class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-ae-100 border border-ae-200/60 text-xs font-medium text-ae-600 mb-6">
-                <span class="w-1.5 h-1.5 rounded-full bg-green-500"></span>
+    <section class="relative pt-28 pb-20 sm:pt-32 sm:pb-24 overflow-hidden bg-ae-900 text-white">
+        <div class="absolute inset-0 hero-glow pointer-events-none"></div>
+        <div class="relative max-w-7xl mx-auto px-6 sm:px-8">
+            <p class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-white/10 border border-white/15 text-xs font-medium text-ae-200 mb-6">
+                <span class="w-1.5 h-1.5 rounded-full bg-brand-500 animate-pulse"></span>
                 Open-source india-banking suite – 31+ ⭐ on GitHub
             </p>
-            <h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight leading-[1.1] mb-6">
-                ERPNext integrations that <span class="text-ae-400">actually work in production</span>
+            <h1 class="font-semibold tracking-tight leading-[1.15] text-white mb-6" style="font-size: clamp(1.5rem, 4.4vw, 3.25rem);">
+                ERPNext integrations that <span class="text-brand-400 font-semibold">actually work in production</span>
             </h1>
-            <p class="text-lg text-ae-500 leading-relaxed max-w-2xl mb-8">
+            <p class="text-lg text-ae-200 leading-relaxed max-w-2xl mb-8">
                 Bank APIs, e-commerce platforms, warehouse robotics, electronic signatures – we've integrated ERPNext with systems that process real money and move real inventory. Most of our integration work is open source, so you can audit the code before you hire us.
             </p>
             <div class="flex flex-wrap gap-4">
-                <a href="mailto:hello@aerele.in" class="px-6 py-3 bg-ae-900 text-ae-50 rounded-full text-sm font-medium hover:bg-ae-800 transition-colors">Discuss your integration →</a>
-                <a href="https://github.com/aerele/india-banking" class="px-6 py-3 border border-ae-300 text-ae-700 rounded-full text-sm font-medium hover:border-ae-400 transition-colors">See india-banking →</a>
+                <a href="mailto:hello@aerele.in" class="px-6 py-3 bg-brand-500 hover:bg-brand-600 text-white rounded-lg text-sm font-medium transition-colors">Discuss your integration →</a>
+                <a href="https://github.com/aerele/india-banking" class="px-6 py-3 border border-white/15 text-white rounded-lg text-sm font-medium hover:border-white/30 transition-colors">See india-banking →</a>
             </div>
         </div>
     </section>
 
     <!-- Bank Integrations (the crown jewel) -->
     <section class="py-20 bg-ae-950 text-ae-50">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-4">India Banking Suite</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-white mb-4">India Banking Suite</h2>
             <p class="text-ae-400 mb-12">Open-source ERPNext integration with 12+ Indian banks. Vendor payouts, payroll disbursement, and bank statement reconciliation – directly from ERPNext.</p>
 
             <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-12">
@@ -133,8 +167,8 @@
 
     <!-- Other integrations -->
     <section class="py-20 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-12">Other ERPNext integrations we've built</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-12">Other ERPNext integrations we've built</h2>
 
             <div class="space-y-10">
                 <div>
@@ -163,7 +197,7 @@
 
     <!-- Open source credibility -->
     <section class="py-16 border-t border-ae-200/60 bg-ae-100/50">
-        <div class="max-w-3xl mx-auto px-6 text-center">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8 text-center">
             <h2 class="text-2xl font-bold mb-4">All of this is open source</h2>
             <p class="text-ae-500 mb-8 max-w-xl mx-auto">You don't have to take our word for it. Our integration code is on GitHub. Read the code, check the commit history, see how we work before you hire us.</p>
             <div class="flex flex-wrap justify-center gap-4">
@@ -177,7 +211,7 @@
 
     <!-- Related -->
     <section class="py-16 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
             <h2 class="text-xl font-bold mb-8">Related services</h2>
             <div class="grid sm:grid-cols-3 gap-4">
                 <a href="/hire-frappe-developer/" class="border border-ae-200 rounded-lg p-5 hover:border-ae-400 transition-colors">
@@ -198,15 +232,15 @@
 
     <!-- CTA -->
     <section class="py-20 bg-ae-950 text-ae-50">
-        <div class="max-w-2xl mx-auto px-6 text-center">
-            <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight mb-4">Need to connect ERPNext to something?</h2>
+        <div class="max-w-2xl mx-auto px-6 sm:px-8 text-center">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-white mb-4">Need to connect ERPNext to something?</h2>
             <p class="text-ae-400 mb-8">Bank API, payment gateway, e-commerce platform, warehouse system, or something we haven't heard of yet – tell us what needs connecting.</p>
-            <a href="mailto:hello@aerele.in" class="inline-block px-8 py-3.5 bg-white text-ae-950 rounded-full text-sm font-semibold hover:bg-ae-100 transition-colors">hello@aerele.in →</a>
+            <a href="mailto:hello@aerele.in" class="inline-block px-8 py-3.5 bg-brand-500 text-white rounded-lg text-sm font-semibold hover:bg-brand-600 transition-colors">hello@aerele.in →</a>
         </div>
     </section>
 
     <footer class="py-10 border-t border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6 flex flex-col sm:flex-row items-center justify-between gap-4 text-xs text-ae-400">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8 flex flex-col sm:flex-row items-center justify-between gap-4 text-xs text-ae-400">
             <p>© 2025 Aerele Technologies Pvt Ltd · Tiruppur, India</p>
             <div class="flex gap-6">
                 <a href="/" class="hover:text-ae-700">Home</a>

--- a/erpnext-performance-optimization/index.html
+++ b/erpnext-performance-optimization/index.html
@@ -72,47 +72,84 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico"><link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png"><link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png"><link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
-        tailwind.config = { theme: { extend: { colors: { 'ae': { 50:'#fafaf9',100:'#f0efed',200:'#e2e0dc',300:'#c8c4be',400:'#a9a49b',500:'#918b80',600:'#7a746a',700:'#5e5a52',800:'#3d3a35',900:'#1c1b18',950:'#0d0c0b' } }, fontFamily: { sans: ['Inter','system-ui','-apple-system','sans-serif'] } } } }
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        'ae': {
+                            50:  '#f7f8fb', 100: '#eef2fb', 200: '#e4e9f5', 300: '#c9d2e8',
+                            400: '#94a3b8', 500: '#64748b', 600: '#475569', 700: '#1e293b',
+                            800: '#0a1a3f', 900: '#060f2b', 950: '#05102a',
+                        },
+                        'brand': {
+                            50:  '#ecfdf5', 100: '#d1fae5', 200: '#a7f3d0', 300: '#6ee7b7',
+                            400: '#34d399', 500: '#10b981', 600: '#059669', 700: '#047857',
+                            800: '#065f46', 900: '#064e3b',
+                        }
+                    },
+                    fontFamily: {
+                        sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
+                    }
+                }
+            }
+        }
     </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-    <style>html{scroll-behavior:smooth;overflow-x:hidden}body{overflow-x:hidden;font-family:'Inter',system-ui,sans-serif}</style>
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" as="style">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="preload" href="/logo-nav.png" as="image">
+    <style>
+        html { scroll-behavior: smooth; overflow-x: hidden; }
+        body { font-family: 'Inter', system-ui, sans-serif; overflow-x: hidden; }
+        .fade-in { opacity: 0; transform: translateY(16px); transition: opacity 0.5s ease, transform 0.5s ease; }
+        .fade-in.visible { opacity: 1; transform: translateY(0); }
+        .hero-glow { background: radial-gradient(ellipse 80% 60% at 30% 30%, rgba(16,185,129,0.08), transparent 70%), radial-gradient(ellipse 60% 50% at 80% 20%, rgba(26,50,116,0.4), transparent 70%); }
+    </style>
 </head>
 <body class="bg-ae-50 text-ae-900 antialiased">
 
-    <nav class="fixed top-0 w-full bg-ae-50/80 backdrop-blur-md z-50 border-b border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
-            <a href="/" class="flex items-center gap-2.5"><img src="/logo-nav.png" alt="Aerele Technologies" class="h-8"><span class="text-[15px] font-semibold text-ae-900 tracking-tight">Aerele Technologies</span></a>
-            <div class="hidden sm:flex items-center gap-8 text-[13px] text-ae-500">
-                <a href="/" class="hover:text-ae-900">Home</a>
-                <a href="/hire-frappe-developer/" class="hover:text-ae-900">Hire Developers</a>
-                <a href="/erpnext-customization/" class="hover:text-ae-900">Customization</a>
-                <a href="/erpnext-integration/" class="hover:text-ae-900">Integrations</a>
-                <a href="tel:+917790844832" class="px-4 py-1.5 bg-ae-900 text-ae-50 rounded-full hover:bg-ae-800">Get in touch</a>
+    <nav class="fixed top-0 w-full bg-white/90 backdrop-blur-md z-50 border-b border-ae-200/60">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8 py-4 flex items-center justify-between">
+            <a href="/" class="flex items-center gap-2.5">
+                <img src="/logo-nav.png" alt="Aerele Technologies" class="h-8">
+                <span class="text-[16px] font-semibold text-ae-900 tracking-tight">Aerele Technologies</span>
+            </a>
+            <div class="hidden sm:flex items-center gap-8 text-[14px] font-medium text-ae-600">
+                <a href="/" class="hover:text-ae-900 transition-colors">Home</a>
+                <a href="/hire-frappe-developer/" class="hover:text-ae-900 transition-colors">Hire Developers</a>
+                <a href="/erpnext-customization/" class="hover:text-ae-900 transition-colors">Customization</a>
+                <a href="/erpnext-integration/" class="hover:text-ae-900 transition-colors">Integrations</a>
+                <a href="/about/" class="hover:text-ae-900 transition-colors">About</a>
+                <a href="/hire-frappe-developer/" class="inline-flex items-center gap-1.5 px-4 py-2 bg-ae-900 text-white rounded-lg font-semibold hover:bg-ae-800 transition-colors">Hire us <span aria-hidden="true">→</span></a>
             </div>
+            <button class="sm:hidden p-2 text-ae-600" aria-label="Menu">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
+            </button>
         </div>
     </nav>
 
-    <section class="pt-32 pb-16 sm:pt-44 sm:pb-24">
-        <div class="max-w-3xl mx-auto px-6">
-            <p class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-ae-100 border border-ae-200/60 text-xs font-medium text-ae-600 mb-6">
-                <span class="w-1.5 h-1.5 rounded-full bg-green-500"></span>
+    <section class="relative pt-28 pb-20 sm:pt-32 sm:pb-24 overflow-hidden bg-ae-900 text-white">
+        <div class="absolute inset-0 hero-glow pointer-events-none"></div>
+        <div class="relative max-w-7xl mx-auto px-6 sm:px-8">
+            <p class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-white/10 border border-white/15 text-xs font-medium text-ae-200 mb-6">
+                <span class="w-1.5 h-1.5 rounded-full bg-brand-500 animate-pulse"></span>
                 Optimized by Frappe core contributors
             </p>
-            <h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight leading-[1.1] mb-6">
-                ERPNext running slow? <span class="text-ae-400">We've fixed that.</span>
+            <h1 class="font-semibold tracking-tight leading-[1.15] text-white mb-6" style="font-size: clamp(1.5rem, 4.4vw, 3.25rem);">
+                ERPNext running slow? <span class="text-brand-400 font-semibold">We've fixed that.</span>
             </h1>
-            <p class="text-lg text-ae-500 leading-relaxed max-w-2xl mb-8">
+            <p class="text-lg text-ae-200 leading-relaxed max-w-2xl mb-8">
                 We've taken 8-hour batch jobs down to under a minute. Not by throwing hardware at the problem – by understanding the Frappe framework at the source level and fixing the actual bottleneck. Our developers contribute to Frappe core, so they know where the framework is fast, where it's slow, and how to work with both.
             </p>
-            <a href="mailto:hello@aerele.in" class="inline-block px-6 py-3 bg-ae-900 text-ae-50 rounded-full text-sm font-medium hover:bg-ae-800 transition-colors">Get a performance audit →</a>
+            <a href="mailto:hello@aerele.in" class="inline-block px-6 py-3 bg-brand-500 hover:bg-brand-600 text-white rounded-lg text-sm font-medium transition-colors">Get a performance audit →</a>
         </div>
     </section>
 
     <!-- The headline result -->
     <section class="py-16 border-t border-ae-200/60 bg-ae-950 text-ae-50">
-        <div class="max-w-3xl mx-auto px-6 text-center">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8 text-center">
             <div class="grid grid-cols-3 gap-8">
                 <div>
                     <p class="text-4xl font-extrabold text-red-400">8 hrs</p>
@@ -122,7 +159,7 @@
                     <p class="text-4xl font-extrabold text-ae-400">→</p>
                 </div>
                 <div>
-                    <p class="text-4xl font-extrabold text-green-400">&lt;1 min</p>
+                    <p class="text-4xl font-extrabold text-brand-400">&lt;1 min</p>
                     <p class="text-xs text-ae-400 mt-1">After optimization</p>
                 </div>
             </div>
@@ -131,8 +168,8 @@
     </section>
 
     <section class="py-20 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-4">Common ERPNext performance problems we fix</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-4">Common ERPNext performance problems we fix</h2>
             <p class="text-ae-500 mb-12">Most ERPNext performance issues are code problems, not infrastructure problems. Adding more RAM won't fix an N+1 query that runs 10,000 times per page load.</p>
 
             <div class="space-y-10">
@@ -165,8 +202,8 @@
     </section>
 
     <section class="py-20 bg-ae-950 text-ae-50">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-4">Our approach to performance optimization</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-white mb-4">Our approach to performance optimization</h2>
             <p class="text-ae-400 mb-12">We don't guess. We measure, identify, fix, and verify.</p>
 
             <div class="space-y-8">
@@ -203,8 +240,8 @@
     </section>
 
     <section class="py-20 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-4">Why Frappe contributors optimize better</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-4">Why Frappe contributors optimize better</h2>
             <p class="text-ae-500 leading-relaxed mb-8">When your optimizer has contributed to the framework's query builder, ORM, and caching layer, they know where the performance boundaries are. They know which Frappe methods are O(1) and which are O(n). They know what gets cached and what doesn't. They don't need to reverse-engineer the framework – they helped build it.</p>
             <p class="text-ae-500 leading-relaxed">That's the difference between someone who profiles your code and someone who profiles your code AND knows the framework internals well enough to suggest a change to how the framework itself handles your use case.</p>
         </div>
@@ -212,8 +249,8 @@
 
     <!-- FAQ -->
     <section class="py-20 border-t border-ae-200/60 bg-ae-100/50">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-12">Frequently asked questions</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-12">Frequently asked questions</h2>
             <div class="space-y-6">
                 <details class="group" open>
                     <summary class="flex items-center justify-between cursor-pointer py-4 border-b border-ae-200/60 text-sm font-semibold text-ae-900">
@@ -241,15 +278,15 @@
     </section>
 
     <section class="py-20 bg-ae-950 text-ae-50">
-        <div class="max-w-2xl mx-auto px-6 text-center">
-            <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight mb-4">ERPNext slow? Let's fix it.</h2>
+        <div class="max-w-2xl mx-auto px-6 sm:px-8 text-center">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-white mb-4">ERPNext slow? Let's fix it.</h2>
             <p class="text-ae-400 mb-8">Tell us what's slow – reports, batch jobs, form loads, the whole system. We'll profile it and give you an honest assessment of what's fixable and how long it'll take.</p>
-            <a href="mailto:hello@aerele.in" class="inline-block px-8 py-3.5 bg-white text-ae-950 rounded-full text-sm font-semibold hover:bg-ae-100 transition-colors">hello@aerele.in →</a>
+            <a href="mailto:hello@aerele.in" class="inline-block px-8 py-3.5 bg-brand-500 text-white rounded-lg text-sm font-semibold hover:bg-brand-600 transition-colors">hello@aerele.in →</a>
         </div>
     </section>
 
     <footer class="py-10 border-t border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6 flex flex-col sm:flex-row items-center justify-between gap-4 text-xs text-ae-400">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8 flex flex-col sm:flex-row items-center justify-between gap-4 text-xs text-ae-400">
             <p>© 2025 Aerele Technologies Pvt Ltd · Tiruppur, India</p>
             <div class="flex gap-6">
                 <a href="/" class="hover:text-ae-700">Home</a>

--- a/frappe-product-engineering/index.html
+++ b/frappe-product-engineering/index.html
@@ -40,46 +40,83 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico"><link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png"><link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png"><link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
-        tailwind.config = { theme: { extend: { colors: { 'ae': { 50:'#fafaf9',100:'#f0efed',200:'#e2e0dc',300:'#c8c4be',400:'#a9a49b',500:'#918b80',600:'#7a746a',700:'#5e5a52',800:'#3d3a35',900:'#1c1b18',950:'#0d0c0b' } }, fontFamily: { sans: ['Inter','system-ui','-apple-system','sans-serif'] } } } }
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        'ae': {
+                            50:  '#f7f8fb', 100: '#eef2fb', 200: '#e4e9f5', 300: '#c9d2e8',
+                            400: '#94a3b8', 500: '#64748b', 600: '#475569', 700: '#1e293b',
+                            800: '#0a1a3f', 900: '#060f2b', 950: '#05102a',
+                        },
+                        'brand': {
+                            50:  '#ecfdf5', 100: '#d1fae5', 200: '#a7f3d0', 300: '#6ee7b7',
+                            400: '#34d399', 500: '#10b981', 600: '#059669', 700: '#047857',
+                            800: '#065f46', 900: '#064e3b',
+                        }
+                    },
+                    fontFamily: {
+                        sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
+                    }
+                }
+            }
+        }
     </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-    <style>html{scroll-behavior:smooth;overflow-x:hidden}body{overflow-x:hidden;font-family:'Inter',system-ui,sans-serif}</style>
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" as="style">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="preload" href="/logo-nav.png" as="image">
+    <style>
+        html { scroll-behavior: smooth; overflow-x: hidden; }
+        body { font-family: 'Inter', system-ui, sans-serif; overflow-x: hidden; }
+        .fade-in { opacity: 0; transform: translateY(16px); transition: opacity 0.5s ease, transform 0.5s ease; }
+        .fade-in.visible { opacity: 1; transform: translateY(0); }
+        .hero-glow { background: radial-gradient(ellipse 80% 60% at 30% 30%, rgba(16,185,129,0.08), transparent 70%), radial-gradient(ellipse 60% 50% at 80% 20%, rgba(26,50,116,0.4), transparent 70%); }
+    </style>
 </head>
 <body class="bg-ae-50 text-ae-900 antialiased">
 
-    <nav class="fixed top-0 w-full bg-ae-50/80 backdrop-blur-md z-50 border-b border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
-            <a href="/" class="flex items-center gap-2.5"><img src="/logo-nav.png" alt="Aerele Technologies" class="h-8"><span class="text-[15px] font-semibold text-ae-900 tracking-tight">Aerele Technologies</span></a>
-            <div class="hidden sm:flex items-center gap-8 text-[13px] text-ae-500">
-                <a href="/" class="hover:text-ae-900">Home</a>
-                <a href="/hire-frappe-developer/" class="hover:text-ae-900">Hire Developers</a>
-                <a href="/erpnext-customization/" class="hover:text-ae-900">Customization</a>
-                <a href="/erpnext-integration/" class="hover:text-ae-900">Integrations</a>
-                <a href="tel:+917790844832" class="px-4 py-1.5 bg-ae-900 text-ae-50 rounded-full hover:bg-ae-800">Get in touch</a>
+    <nav class="fixed top-0 w-full bg-white/90 backdrop-blur-md z-50 border-b border-ae-200/60">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8 py-4 flex items-center justify-between">
+            <a href="/" class="flex items-center gap-2.5">
+                <img src="/logo-nav.png" alt="Aerele Technologies" class="h-8">
+                <span class="text-[16px] font-semibold text-ae-900 tracking-tight">Aerele Technologies</span>
+            </a>
+            <div class="hidden sm:flex items-center gap-8 text-[14px] font-medium text-ae-600">
+                <a href="/" class="hover:text-ae-900 transition-colors">Home</a>
+                <a href="/hire-frappe-developer/" class="hover:text-ae-900 transition-colors">Hire Developers</a>
+                <a href="/erpnext-customization/" class="hover:text-ae-900 transition-colors">Customization</a>
+                <a href="/erpnext-integration/" class="hover:text-ae-900 transition-colors">Integrations</a>
+                <a href="/about/" class="hover:text-ae-900 transition-colors">About</a>
+                <a href="/hire-frappe-developer/" class="inline-flex items-center gap-1.5 px-4 py-2 bg-ae-900 text-white rounded-lg font-semibold hover:bg-ae-800 transition-colors">Hire us <span aria-hidden="true">→</span></a>
             </div>
+            <button class="sm:hidden p-2 text-ae-600" aria-label="Menu">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
+            </button>
         </div>
     </nav>
 
-    <section class="pt-32 pb-16 sm:pt-44 sm:pb-24">
-        <div class="max-w-3xl mx-auto px-6">
-            <p class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-ae-100 border border-ae-200/60 text-xs font-medium text-ae-600 mb-6">
-                <span class="w-1.5 h-1.5 rounded-full bg-green-500"></span>
+    <section class="relative pt-28 pb-20 sm:pt-32 sm:pb-24 overflow-hidden bg-ae-900 text-white">
+        <div class="absolute inset-0 hero-glow pointer-events-none"></div>
+        <div class="relative max-w-7xl mx-auto px-6 sm:px-8">
+            <p class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-white/10 border border-white/15 text-xs font-medium text-ae-200 mb-6">
+                <span class="w-1.5 h-1.5 rounded-full bg-brand-500 animate-pulse"></span>
                 Engineering team behind Stanch.io, AssureAI, Xavica Software, Ziyana Software
             </p>
-            <h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight leading-[1.1] mb-6">
-                Build your product on Frappe <span class="text-ae-400">with the team that builds Frappe</span>
+            <h1 class="font-semibold tracking-tight leading-[1.15] text-white mb-6" style="font-size: clamp(1.5rem, 4.4vw, 3.25rem);">
+                Build your product on Frappe <span class="text-brand-400 font-semibold">with the team that builds Frappe</span>
             </h1>
-            <p class="text-lg text-ae-500 leading-relaxed max-w-2xl mb-8">
+            <p class="text-lg text-ae-200 leading-relaxed max-w-2xl mb-8">
                 Product companies hire us to be their engineering team on Frappe. Architecture, development, testing, deployment – end to end. We've built entire products for SaaS companies and startups who chose Frappe as their foundation. Our team's 600+ contributions to the framework itself mean we know what it can do, what it can't, and how to push it further.
             </p>
-            <a href="mailto:hello@aerele.in" class="inline-block px-6 py-3 bg-ae-900 text-ae-50 rounded-full text-sm font-medium hover:bg-ae-800 transition-colors">Tell us about your product →</a>
+            <a href="mailto:hello@aerele.in" class="inline-block px-6 py-3 bg-brand-500 hover:bg-brand-600 text-white rounded-lg text-sm font-medium transition-colors">Tell us about your product →</a>
         </div>
     </section>
 
     <section class="py-16 border-t border-ae-200/60 bg-ae-100/50">
-        <div class="max-w-3xl mx-auto px-6">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
             <p class="text-xs text-ae-400 uppercase tracking-widest mb-6 text-center">Products built by Aerele's engineering team</p>
             <div class="flex flex-wrap justify-center gap-x-10 gap-y-3 text-sm text-ae-500 font-medium">
                 <span>Stanch.io</span>
@@ -91,8 +128,8 @@
     </section>
 
     <section class="py-20 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-4">Why build on Frappe?</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-4">Why build on Frappe?</h2>
             <p class="text-ae-500 mb-12">Frappe gives you an ORM, REST API, permissions, background jobs, email, print formats, a web framework, and a UI toolkit out of the box. Instead of building infrastructure, you build product.</p>
 
             <div class="space-y-8">
@@ -113,8 +150,8 @@
     </section>
 
     <section class="py-20 bg-ae-950 text-ae-50">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-4">What product engineering with Aerele looks like</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-white mb-4">What product engineering with Aerele looks like</h2>
             <p class="text-ae-400 mb-12">We don't just write code. We help you make architectural decisions that determine whether your product scales or doesn't.</p>
 
             <div class="space-y-8">
@@ -147,8 +184,8 @@
     </section>
 
     <section class="py-20 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-4">How we engage for product work</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-4">How we engage for product work</h2>
             <p class="text-ae-500 mb-12">Product engineering needs continuity. We recommend the dedicated resource model for product companies.</p>
 
             <div class="border border-ae-200 rounded-xl p-8">
@@ -167,15 +204,15 @@
     </section>
 
     <section class="py-20 bg-ae-950 text-ae-50">
-        <div class="max-w-2xl mx-auto px-6 text-center">
-            <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight mb-4">Building a product on Frappe?</h2>
+        <div class="max-w-2xl mx-auto px-6 sm:px-8 text-center">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-white mb-4">Building a product on Frappe?</h2>
             <p class="text-ae-400 mb-8">Tell us what you're building. We'll tell you whether Frappe is the right foundation – and if it is, how we'd architect it.</p>
-            <a href="mailto:hello@aerele.in" class="inline-block px-8 py-3.5 bg-white text-ae-950 rounded-full text-sm font-semibold hover:bg-ae-100 transition-colors">hello@aerele.in →</a>
+            <a href="mailto:hello@aerele.in" class="inline-block px-8 py-3.5 bg-brand-500 text-white rounded-lg text-sm font-semibold hover:bg-brand-600 transition-colors">hello@aerele.in →</a>
         </div>
     </section>
 
     <footer class="py-10 border-t border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6 flex flex-col sm:flex-row items-center justify-between gap-4 text-xs text-ae-400">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8 flex flex-col sm:flex-row items-center justify-between gap-4 text-xs text-ae-400">
             <p>© 2025 Aerele Technologies Pvt Ltd · Tiruppur, India</p>
             <div class="flex gap-6">
                 <a href="/" class="hover:text-ae-700">Home</a>

--- a/hire-erpnext-developer/index.html
+++ b/hire-erpnext-developer/index.html
@@ -128,59 +128,83 @@
                 extend: {
                     colors: {
                         'ae': {
-                            50: '#fafaf9', 100: '#f0efed', 200: '#e2e0dc', 300: '#c8c4be',
-                            400: '#a9a49b', 500: '#918b80', 600: '#7a746a', 700: '#5e5a52',
-                            800: '#3d3a35', 900: '#1c1b18', 950: '#0d0c0b',
+                            50:  '#f7f8fb', 100: '#eef2fb', 200: '#e4e9f5', 300: '#c9d2e8',
+                            400: '#94a3b8', 500: '#64748b', 600: '#475569', 700: '#1e293b',
+                            800: '#0a1a3f', 900: '#060f2b', 950: '#05102a',
+                        },
+                        'brand': {
+                            50:  '#ecfdf5', 100: '#d1fae5', 200: '#a7f3d0', 300: '#6ee7b7',
+                            400: '#34d399', 500: '#10b981', 600: '#059669', 700: '#047857',
+                            800: '#065f46', 900: '#064e3b',
                         }
                     },
-                    fontFamily: { sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'] }
+                    fontFamily: {
+                        sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
+                    }
                 }
             }
         }
     </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-    <style>html{scroll-behavior:smooth;overflow-x:hidden}body{overflow-x:hidden;font-family:'Inter',system-ui,sans-serif}</style>
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" as="style">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="preload" href="/logo-nav.png" as="image">
+    <style>
+        html { scroll-behavior: smooth; overflow-x: hidden; }
+        body { font-family: 'Inter', system-ui, sans-serif; overflow-x: hidden; }
+        .fade-in { opacity: 0; transform: translateY(16px); transition: opacity 0.5s ease, transform 0.5s ease; }
+        .fade-in.visible { opacity: 1; transform: translateY(0); }
+        .hero-glow { background: radial-gradient(ellipse 80% 60% at 30% 30%, rgba(16,185,129,0.08), transparent 70%), radial-gradient(ellipse 60% 50% at 80% 20%, rgba(26,50,116,0.4), transparent 70%); }
+    </style>
 </head>
 <body class="bg-ae-50 text-ae-900 antialiased">
 
-    <nav class="fixed top-0 w-full bg-ae-50/80 backdrop-blur-md z-50 border-b border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
-            <a href="/" class="flex items-center gap-2.5"><img src="/logo-nav.png" alt="Aerele Technologies" class="h-8"><span class="text-[15px] font-semibold text-ae-900 tracking-tight">Aerele Technologies</span></a>
-            <div class="hidden sm:flex items-center gap-8 text-[13px] text-ae-500">
-                <a href="/" class="hover:text-ae-900">Home</a>
-                <a href="/erpnext-customization/" class="hover:text-ae-900">Customization</a>
-                <a href="/erpnext-integration/" class="hover:text-ae-900">Integrations</a>
-                <a href="/about/" class="hover:text-ae-900">About</a>
-                <a href="tel:+917790844832" class="px-4 py-1.5 bg-ae-900 text-ae-50 rounded-full hover:bg-ae-800">Get in touch</a>
+    <nav class="fixed top-0 w-full bg-white/90 backdrop-blur-md z-50 border-b border-ae-200/60">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8 py-4 flex items-center justify-between">
+            <a href="/" class="flex items-center gap-2.5">
+                <img src="/logo-nav.png" alt="Aerele Technologies" class="h-8">
+                <span class="text-[16px] font-semibold text-ae-900 tracking-tight">Aerele Technologies</span>
+            </a>
+            <div class="hidden sm:flex items-center gap-8 text-[14px] font-medium text-ae-600">
+                <a href="/" class="hover:text-ae-900 transition-colors">Home</a>
+                <a href="/hire-frappe-developer/" class="hover:text-ae-900 transition-colors">Hire Developers</a>
+                <a href="/erpnext-customization/" class="hover:text-ae-900 transition-colors">Customization</a>
+                <a href="/erpnext-integration/" class="hover:text-ae-900 transition-colors">Integrations</a>
+                <a href="/about/" class="hover:text-ae-900 transition-colors">About</a>
+                <a href="/hire-frappe-developer/" class="inline-flex items-center gap-1.5 px-4 py-2 bg-ae-900 text-white rounded-lg font-semibold hover:bg-ae-800 transition-colors">Hire us <span aria-hidden="true">→</span></a>
             </div>
+            <button class="sm:hidden p-2 text-ae-600" aria-label="Menu">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
+            </button>
         </div>
     </nav>
 
     <!-- Hero -->
-    <section class="pt-32 pb-16 sm:pt-44 sm:pb-24">
-        <div class="max-w-3xl mx-auto px-6">
-            <p class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-ae-100 border border-ae-200/60 text-xs font-medium text-ae-600 mb-6">
-                <span class="w-1.5 h-1.5 rounded-full bg-green-500"></span>
+    <section class="relative pt-28 pb-20 sm:pt-32 sm:pb-24 overflow-hidden bg-ae-900 text-white">
+        <div class="absolute inset-0 hero-glow pointer-events-none"></div>
+        <div class="relative max-w-7xl mx-auto px-6 sm:px-8">
+            <p class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-white/10 border border-white/15 text-xs font-medium text-ae-200 mb-6">
+                <span class="w-1.5 h-1.5 rounded-full bg-brand-500 animate-pulse"></span>
                 600+ pull requests merged into ERPNext core
             </p>
-            <h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight leading-[1.1] mb-6">
-                Hire ERPNext developers who <span class="text-ae-400">contribute to the source code</span>
+            <h1 class="font-semibold tracking-tight leading-[1.15] text-white mb-6" style="font-size: clamp(1.5rem, 4.4vw, 3.25rem);">
+                Hire ERPNext developers who <span class="text-brand-400 font-semibold">contribute to the source code</span>
             </h1>
-            <p class="text-lg text-ae-500 leading-relaxed max-w-2xl mb-8">
+            <p class="text-lg text-ae-200 leading-relaxed max-w-2xl mb-8">
                 ERPNext is built on the Frappe framework. The best ERPNext developers aren't just people who configure it – they're people who understand the framework underneath. Our team has 600+ pull requests merged into ERPNext, Frappe, HRMS, Payments, and Webshop. That means when something breaks in your ERPNext, our developers can trace it to the source, not just Google the error message.
             </p>
             <div class="flex flex-wrap gap-4">
-                <a href="mailto:hello@aerele.in" class="px-6 py-3 bg-ae-900 text-ae-50 rounded-full text-sm font-medium hover:bg-ae-800 transition-colors">Start a conversation →</a>
-                <a href="/hire-frappe-developer/" class="px-6 py-3 border border-ae-300 text-ae-700 rounded-full text-sm font-medium hover:border-ae-400 transition-colors">See full developer page →</a>
+                <a href="mailto:hello@aerele.in" class="px-6 py-3 bg-brand-500 hover:bg-brand-600 text-white rounded-lg text-sm font-medium transition-colors">Start a conversation →</a>
+                <a href="/hire-frappe-developer/" class="px-6 py-3 border border-white/15 text-white rounded-lg text-sm font-medium hover:border-white/30 transition-colors">See full developer page →</a>
             </div>
         </div>
     </section>
 
     <!-- ERPNext = Frappe explanation -->
     <section class="py-16 border-t border-ae-200/60 bg-ae-100/50">
-        <div class="max-w-3xl mx-auto px-6">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
             <h2 class="text-xl font-bold mb-4">ERPNext runs on Frappe. The best ERPNext developer is a Frappe developer.</h2>
             <p class="text-ae-500 leading-relaxed">Every ERPNext customization, integration, and performance fix ultimately touches the Frappe framework. Custom doctypes? Frappe. REST APIs? Frappe. Background jobs? Frappe. Permissions? Frappe. The ERPNext developer who understands Frappe deeply – and has contributed to it – will always outperform one who only knows the ERPNext UI layer. That's why <a href="/hire-frappe-developer/" class="underline text-ae-700">our hiring page focuses on Frappe expertise</a>: it's the foundation that determines how good your ERPNext developer actually is.</p>
         </div>
@@ -188,8 +212,8 @@
 
     <!-- Meet the developers -->
     <section class="py-20 border-t border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-4">Meet the developers who contribute to ERPNext</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-4">Meet the developers who contribute to ERPNext</h2>
             <p class="text-ae-500 mb-12">Every person below has pull requests merged into the ERPNext ecosystem. Each card shows their ERPNext-specific contributions. Click to verify on GitHub.</p>
 
             <div id="erpnext-contributors-grid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
@@ -200,8 +224,8 @@
 
     <!-- What ERPNext work we do -->
     <section class="py-20 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-4">What our ERPNext developers build</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-4">What our ERPNext developers build</h2>
             <p class="text-ae-500 mb-12">These aren't hypothetical. These are shipped, production systems across India, Oman, UAE, and Germany.</p>
 
             <div class="grid sm:grid-cols-2 gap-6">
@@ -235,8 +259,8 @@
 
     <!-- ERPNext modules we contribute to -->
     <section class="py-20 bg-ae-950 text-ae-50">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-4">ERPNext modules our developers have contributed to</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-white mb-4">ERPNext modules our developers have contributed to</h2>
             <p class="text-ae-400 mb-12">Pull requests merged into these core ERPNext ecosystem repositories. Publicly verifiable on GitHub.</p>
 
             <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
@@ -278,8 +302,8 @@
 
     <!-- Pricing -->
     <section class="py-20 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-4">ERPNext developer pricing</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-4">ERPNext developer pricing</h2>
             <p class="text-ae-500 mb-10">Transparent. No "schedule a call" to see numbers.</p>
 
             <div class="space-y-4">
@@ -339,8 +363,8 @@
 
     <!-- FAQ -->
     <section class="py-20 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl font-bold tracking-tight mb-12">Frequently asked questions about hiring ERPNext developers</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-12">Frequently asked questions about hiring ERPNext developers</h2>
             <div class="space-y-6">
                 <details class="group" open>
                     <summary class="flex items-center justify-between cursor-pointer py-4 border-b border-ae-200/60 text-sm font-semibold text-ae-900">
@@ -383,19 +407,19 @@
 
     <!-- CTA -->
     <section class="py-20 bg-ae-950 text-ae-50">
-        <div class="max-w-2xl mx-auto px-6 text-center">
-            <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight mb-4">Your next ERPNext developer should be a contributor</h2>
+        <div class="max-w-2xl mx-auto px-6 sm:px-8 text-center">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-white mb-4">Your next ERPNext developer should be a contributor</h2>
             <p class="text-ae-400 mb-8">Tell us what you're building on ERPNext. We'll tell you if we're the right fit.</p>
             <div class="flex flex-wrap justify-center gap-4">
-                <a href="mailto:hello@aerele.in" class="px-8 py-3.5 bg-white text-ae-950 rounded-full text-sm font-semibold hover:bg-ae-100 transition-colors">hello@aerele.in →</a>
-                <a href="tel:+917790844832" class="px-8 py-3.5 border border-ae-700 text-ae-50 rounded-full text-sm font-semibold hover:border-ae-500 transition-colors">+91 77908 44832</a>
-                <a href="/hire-frappe-developer/" class="px-8 py-3.5 border border-ae-700 text-ae-50 rounded-full text-sm font-semibold hover:border-ae-500 transition-colors">Full developer page →</a>
+                <a href="mailto:hello@aerele.in" class="px-8 py-3.5 bg-brand-500 text-white rounded-lg text-sm font-semibold hover:bg-brand-600 transition-colors">hello@aerele.in →</a>
+                <a href="tel:+917790844832" class="px-8 py-3.5 border border-white/15 text-ae-50 rounded-lg text-sm font-semibold hover:border-white/30 transition-colors">+91 77908 44832</a>
+                <a href="/hire-frappe-developer/" class="px-8 py-3.5 border border-white/15 text-ae-50 rounded-lg text-sm font-semibold hover:border-white/30 transition-colors">Full developer page →</a>
             </div>
         </div>
     </section>
 
     <footer class="py-10 border-t border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
             <div class="grid grid-cols-2 sm:grid-cols-4 gap-8 mb-8 text-xs">
                 <div>
                     <p class="font-semibold text-ae-700 mb-3">Services</p>

--- a/hire-frappe-developer/index.html
+++ b/hire-frappe-developer/index.html
@@ -130,67 +130,84 @@
                 extend: {
                     colors: {
                         'ae': {
-                            50: '#fafaf9', 100: '#f0efed', 200: '#e2e0dc', 300: '#c8c4be',
-                            400: '#a9a49b', 500: '#918b80', 600: '#7a746a', 700: '#5e5a52',
-                            800: '#3d3a35', 900: '#1c1b18', 950: '#0d0c0b',
+                            50:  '#f7f8fb', 100: '#eef2fb', 200: '#e4e9f5', 300: '#c9d2e8',
+                            400: '#94a3b8', 500: '#64748b', 600: '#475569', 700: '#1e293b',
+                            800: '#0a1a3f', 900: '#060f2b', 950: '#05102a',
+                        },
+                        'brand': {
+                            50:  '#ecfdf5', 100: '#d1fae5', 200: '#a7f3d0', 300: '#6ee7b7',
+                            400: '#34d399', 500: '#10b981', 600: '#059669', 700: '#047857',
+                            800: '#065f46', 900: '#064e3b',
                         }
                     },
-                    fontFamily: { sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'] }
+                    fontFamily: {
+                        sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
+                    }
                 }
             }
         }
     </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" as="style">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="preload" href="/logo-nav.png" as="image">
     <style>
         html { scroll-behavior: smooth; overflow-x: hidden; }
-        body { overflow-x: hidden; font-family: 'Inter', system-ui, sans-serif; }
+        body { font-family: 'Inter', system-ui, sans-serif; overflow-x: hidden; }
         .fade-in { opacity: 0; transform: translateY(16px); transition: opacity 0.5s ease, transform 0.5s ease; }
         .fade-in.visible { opacity: 1; transform: translateY(0); }
+        .hero-glow { background: radial-gradient(ellipse 80% 60% at 30% 30%, rgba(16,185,129,0.08), transparent 70%), radial-gradient(ellipse 60% 50% at 80% 20%, rgba(26,50,116,0.4), transparent 70%); }
     </style>
 </head>
 <body class="bg-ae-50 text-ae-900 antialiased">
 
     <!-- Nav -->
-    <nav class="fixed top-0 w-full bg-ae-50/80 backdrop-blur-md z-50 border-b border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
-            <a href="/" class="flex items-center">
+    <nav class="fixed top-0 w-full bg-white/90 backdrop-blur-md z-50 border-b border-ae-200/60">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8 py-4 flex items-center justify-between">
+            <a href="/" class="flex items-center gap-2.5">
                 <img src="/logo-nav.png" alt="Aerele Technologies" class="h-8">
+                <span class="text-[16px] font-semibold text-ae-900 tracking-tight">Aerele Technologies</span>
             </a>
-            <div class="hidden sm:flex items-center gap-8 text-[13px] text-ae-500">
+            <div class="hidden sm:flex items-center gap-8 text-[14px] font-medium text-ae-600">
                 <a href="/" class="hover:text-ae-900 transition-colors">Home</a>
+                <a href="/hire-frappe-developer/" class="hover:text-ae-900 transition-colors">Hire Developers</a>
                 <a href="/erpnext-customization/" class="hover:text-ae-900 transition-colors">Customization</a>
                 <a href="/erpnext-integration/" class="hover:text-ae-900 transition-colors">Integrations</a>
                 <a href="/about/" class="hover:text-ae-900 transition-colors">About</a>
-                <a href="tel:+917790844832" class="px-4 py-1.5 bg-ae-900 text-ae-50 rounded-full hover:bg-ae-800 transition-colors">Get in touch</a>
+                <a href="/hire-frappe-developer/" class="inline-flex items-center gap-1.5 px-4 py-2 bg-ae-900 text-white rounded-lg font-semibold hover:bg-ae-800 transition-colors">Hire us <span aria-hidden="true">→</span></a>
             </div>
+            <button class="sm:hidden p-2 text-ae-600" aria-label="Menu">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
+            </button>
         </div>
     </nav>
 
     <!-- Hero -->
-    <section class="pt-32 pb-16 sm:pt-44 sm:pb-24">
-        <div class="max-w-3xl mx-auto px-6">
-            <p class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-ae-100 border border-ae-200/60 text-xs font-medium text-ae-600 mb-6">
-                <span class="w-1.5 h-1.5 rounded-full bg-green-500"></span>
+    <section class="relative pt-28 pb-20 sm:pt-32 sm:pb-24 overflow-hidden bg-ae-900 text-white">
+        <div class="absolute inset-0 hero-glow pointer-events-none"></div>
+        <div class="relative max-w-7xl mx-auto px-6 sm:px-8">
+            <p class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-white/10 border border-white/15 text-xs font-medium text-ae-200 mb-6">
+                <span class="w-1.5 h-1.5 rounded-full bg-brand-500 animate-pulse"></span>
                 600+ pull requests merged into Frappe core
             </p>
-            <h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight leading-[1.1] mb-6">
-                Hire Frappe developers who <span class="text-ae-400">contribute to the framework</span>
+            <h1 class="font-semibold tracking-tight leading-[1.15] text-white mb-6" style="font-size: clamp(1.5rem, 4.4vw, 3.25rem);">
+                Hire Frappe developers who <span class="text-brand-400 font-semibold">contribute to the framework</span>
             </h1>
-            <p class="text-lg text-ae-500 leading-relaxed max-w-2xl mb-8">
-                Most Frappe developers configure ERPNext. Ours contribute to it. When you hire from Aerele, you're hiring someone who has merged pull requests into the same codebase your business runs on – ERPNext, Frappe Framework, HRMS, Payments, and Webshop. That's not a marketing claim. It's verifiable on <a href="https://github.com/aerele" class="underline text-ae-700">GitHub</a>.
+            <p class="text-lg text-ae-200 leading-relaxed max-w-2xl mb-8">
+                Most Frappe developers configure ERPNext. Ours contribute to it. When you hire from Aerele, you're hiring someone who has merged pull requests into the same codebase your business runs on – ERPNext, Frappe Framework, HRMS, Payments, and Webshop. That's not a marketing claim. It's verifiable on <a href="https://github.com/aerele" class="underline text-white">GitHub</a>.
             </p>
             <div class="flex flex-wrap gap-4">
-                <a href="mailto:hello@aerele.in" class="px-6 py-3 bg-ae-900 text-ae-50 rounded-full text-sm font-medium hover:bg-ae-800 transition-colors">Start a conversation →</a>
-                <a href="https://github.com/aerele" class="px-6 py-3 border border-ae-300 text-ae-700 rounded-full text-sm font-medium hover:border-ae-400 transition-colors">Verify on GitHub →</a>
+                <a href="mailto:hello@aerele.in" class="px-6 py-3 bg-brand-500 hover:bg-brand-600 text-white rounded-lg text-sm font-medium transition-colors">Start a conversation →</a>
+                <a href="https://github.com/aerele" class="px-6 py-3 border border-white/15 text-white rounded-lg text-sm font-medium hover:border-white/30 transition-colors">Verify on GitHub →</a>
             </div>
         </div>
     </section>
 
     <!-- Numbers bar -->
     <section class="py-12 border-t border-ae-200/60 bg-ae-100/50">
-        <div class="max-w-3xl mx-auto px-6">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
             <div class="grid grid-cols-2 sm:grid-cols-4 gap-8 text-center">
                 <div>
                     <p class="text-3xl font-extrabold">600+</p>
@@ -214,8 +231,8 @@
 
     <!-- Developer vs Contributor -->
     <section class="py-20 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-4">Why hire a Frappe contributor instead of a Frappe developer?</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-4">Why hire a Frappe contributor instead of a Frappe developer?</h2>
             <p class="text-ae-500 mb-12">There are thousands of Frappe developers. There are far fewer who have code merged into the framework itself. Here's why that difference matters for your project:</p>
             
             <div class="space-y-10">
@@ -245,8 +262,8 @@
 
     <!-- Where we contribute -->
     <section class="py-20 bg-ae-950 text-ae-50">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-4">Repositories our developers contribute to</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-white mb-4">Repositories our developers contribute to</h2>
             <p class="text-ae-400 mb-12">Every contribution is publicly verifiable. Click any repository to see our team's merged pull requests.</p>
             
             <div class="grid grid-cols-2 sm:grid-cols-4 gap-6">
@@ -280,8 +297,8 @@
 
     <!-- What our developers can build -->
     <section class="py-20 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-4">What your Frappe developer from Aerele can build</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-4">What your Frappe developer from Aerele can build</h2>
             <p class="text-ae-500 mb-12">These aren't hypothetical capabilities. These are things we've shipped for clients across India, Oman, UAE, and Germany.</p>
 
             <div class="grid sm:grid-cols-2 gap-8">
@@ -343,8 +360,8 @@
 
     <!-- Engagement Models -->
     <section id="pricing" class="py-20 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-4">Three ways to hire Frappe developers</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-4">Three ways to hire Frappe developers</h2>
             <p class="text-ae-500 mb-12">Transparent pricing. No hidden costs. No surprise invoices. Every competitor hides this behind a "schedule a call."</p>
 
             <div class="space-y-6">
@@ -411,8 +428,8 @@
 
     <!-- How it works -->
     <section class="py-20 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-12">How hiring works – three steps</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-12">How hiring works – three steps</h2>
 
             <div class="space-y-8">
                 <div class="flex gap-5">
@@ -442,8 +459,8 @@
 
     <!-- Open source proof -->
     <section class="py-20 bg-ae-950 text-ae-50">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-4">Don't take our word for it. Read the code.</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-white mb-4">Don't take our word for it. Read the code.</h2>
             <p class="text-ae-400 mb-12">Our open-source projects are a live portfolio. See how we write code, handle edge cases, structure applications, and document our work.</p>
 
             <div class="grid sm:grid-cols-2 gap-6">
@@ -481,8 +498,8 @@
 
     <!-- FAQ -->
     <section id="faq" class="py-20 border-t border-ae-200/60">
-        <div class="max-w-3xl mx-auto px-6">
-            <h2 class="text-2xl sm:text-3xl font-bold tracking-tight mb-12">Frequently asked questions about hiring Frappe developers</h2>
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950 mb-12">Frequently asked questions about hiring Frappe developers</h2>
 
             <div class="space-y-6">
                 <details class="group" open>
@@ -554,20 +571,20 @@
 
     <!-- CTA -->
     <section class="py-20 bg-ae-950 text-ae-50">
-        <div class="max-w-2xl mx-auto px-6 text-center">
-            <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight mb-4">Your next Frappe developer should be a contributor</h2>
+        <div class="max-w-2xl mx-auto px-6 sm:px-8 text-center">
+            <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-white mb-4">Your next Frappe developer should be a contributor</h2>
             <p class="text-ae-400 mb-8 max-w-lg mx-auto">Tell us what you're building. We'll tell you if we're the right fit – and if we're not, we'll say so. No sales pitch.</p>
             <div class="flex flex-wrap justify-center gap-4">
-                <a href="mailto:hello@aerele.in" class="px-8 py-3.5 bg-white text-ae-950 rounded-full text-sm font-semibold hover:bg-ae-100 transition-colors">hello@aerele.in →</a>
-                <a href="tel:+917790844832" class="px-8 py-3.5 border border-ae-700 text-ae-50 rounded-full text-sm font-semibold hover:border-ae-500 transition-colors">+91 77908 44832</a>
-                <a href="https://github.com/aerele" class="px-8 py-3.5 border border-ae-700 text-ae-50 rounded-full text-sm font-semibold hover:border-ae-500 transition-colors">View our GitHub →</a>
+                <a href="mailto:hello@aerele.in" class="px-8 py-3.5 bg-brand-500 text-white rounded-lg text-sm font-semibold hover:bg-brand-600 transition-colors">hello@aerele.in →</a>
+                <a href="tel:+917790844832" class="px-8 py-3.5 border border-white/15 text-ae-50 rounded-lg text-sm font-semibold hover:border-white/30 transition-colors">+91 77908 44832</a>
+                <a href="https://github.com/aerele" class="px-8 py-3.5 border border-white/15 text-ae-50 rounded-lg text-sm font-semibold hover:border-white/30 transition-colors">View our GitHub →</a>
             </div>
         </div>
     </section>
 
     <!-- Footer -->
     <footer class="py-10 border-t border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
             <div class="grid grid-cols-2 sm:grid-cols-4 gap-8 mb-8 text-xs">
                 <div>
                     <p class="font-semibold text-ae-700 mb-3">Services</p>

--- a/index.html
+++ b/index.html
@@ -239,21 +239,31 @@
             theme: {
                 extend: {
                     colors: {
+                        // Navy-slate scale (lens.aerele.in design language)
                         'ae': {
-                            50: '#fafaf9', 100: '#f0efed', 200: '#e2e0dc', 300: '#c8c4be',
-                            400: '#a9a49b', 500: '#918b80', 600: '#7a746a', 700: '#5e5a52',
-                            800: '#3d3a35', 900: '#1c1b18', 950: '#0d0c0b',
+                            50:  '#f7f8fb', 100: '#eef2fb', 200: '#e4e9f5', 300: '#c9d2e8',
+                            400: '#94a3b8', 500: '#64748b', 600: '#475569', 700: '#1e293b',
+                            800: '#0a1a3f', 900: '#060f2b', 950: '#05102a',
+                        },
+                        // Emerald accent
+                        'brand': {
+                            50:  '#ecfdf5', 100: '#d1fae5', 200: '#a7f3d0', 300: '#6ee7b7',
+                            400: '#34d399', 500: '#10b981', 600: '#059669', 700: '#047857',
+                            800: '#065f46', 900: '#064e3b',
                         }
                     },
-                    fontFamily: { sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'] }
+                    fontFamily: {
+                        sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
+                    }
                 }
             }
         }
     </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" as="style">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" as="style">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
     <link rel="preload" href="/logo-nav.png" as="image">
     <style>
         html { scroll-behavior: smooth; overflow-x: hidden; }
@@ -263,78 +273,95 @@
         @keyframes scroll-up { 0% { transform: translateY(0); } 100% { transform: translateY(-50%); } }
         .animate-scroll-vertical { animation: scroll-up 50s linear infinite; }
         .animate-scroll-vertical:hover { animation-play-state: paused; }
+        /* Subtle radial glow behind hero — matches lens's depth */
+        .hero-glow { background: radial-gradient(ellipse 80% 60% at 30% 30%, rgba(16,185,129,0.08), transparent 70%), radial-gradient(ellipse 60% 50% at 80% 20%, rgba(26,50,116,0.4), transparent 70%); }
     </style>
 </head>
 <body class="bg-ae-50 text-ae-900 antialiased">
 
     <!-- Nav -->
-    <nav class="fixed top-0 w-full bg-ae-50/80 backdrop-blur-md z-50 border-b border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
+    <nav class="fixed top-0 w-full bg-white/90 backdrop-blur-md z-50 border-b border-ae-200/60">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8 py-4 flex items-center justify-between">
             <a href="#" class="flex items-center gap-2.5">
                 <img src="/logo-nav.png" alt="Aerele Technologies" class="h-8">
-                <span class="text-[15px] font-semibold text-ae-900 tracking-tight">Aerele Technologies</span>
+                <span class="text-[16px] font-semibold text-ae-900 tracking-tight">Aerele Technologies</span>
             </a>
-            <div class="hidden sm:flex items-center gap-8 text-[13px] text-ae-500">
+            <div class="hidden sm:flex items-center gap-8 text-[14px] font-medium text-ae-600">
                 <a href="#why" class="hover:text-ae-900 transition-colors">Why Us</a>
                 <a href="#work" class="hover:text-ae-900 transition-colors">Work</a>
                 <a href="#team" class="hover:text-ae-900 transition-colors">Team</a>
                 <a href="#pricing" class="hover:text-ae-900 transition-colors">Pricing</a>
                 <a href="/about/" class="hover:text-ae-900 transition-colors">About</a>
-                <a href="/hire-frappe-developer/" class="px-4 py-1.5 bg-ae-900 text-ae-50 rounded-full hover:bg-ae-800 transition-colors">Hire us</a>
+                <a href="/hire-frappe-developer/" class="inline-flex items-center gap-1.5 px-4 py-2 bg-ae-900 text-white rounded-lg font-semibold hover:bg-ae-800 transition-colors">Hire us <span aria-hidden="true">→</span></a>
             </div>
             <button id="mobile-menu-btn" class="sm:hidden p-2 text-ae-600" aria-label="Menu">
                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
             </button>
         </div>
-        <div id="mobile-menu" class="hidden sm:hidden border-t border-ae-200 bg-ae-50">
-            <div class="px-6 py-4 flex flex-col gap-4 text-sm text-ae-600">
+        <div id="mobile-menu" class="hidden sm:hidden border-t border-ae-200 bg-white">
+            <div class="px-6 py-4 flex flex-col gap-4 text-sm text-ae-700">
                 <a href="#why">Why Us</a><a href="#work">Work</a><a href="#team">Team</a><a href="#pricing">Pricing</a><a href="/about/">About</a><a href="/hire-frappe-developer/">Hire us</a>
             </div>
         </div>
     </nav>
 
     <!-- ===== HERO ===== -->
-    <section class="pt-32 pb-12 sm:pt-44 sm:pb-20 overflow-hidden">
-        <div class="max-w-5xl mx-auto px-6">
-            <div class="flex flex-col lg:flex-row lg:items-start lg:gap-12">
-                <div class="flex-1 max-w-xl">
+    <section class="relative pt-28 pb-20 sm:pt-32 sm:pb-24 overflow-hidden bg-ae-900 text-white">
+        <div class="absolute inset-0 hero-glow pointer-events-none"></div>
+        <div class="relative max-w-7xl mx-auto px-6 sm:px-8">
+            <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between lg:gap-10">
+                <div class="flex-1 min-w-0 w-full max-w-xl">
                     <!-- The anchor line -->
-                    <p class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-ae-100 border border-ae-200/60 text-xs font-medium text-ae-600 mb-6">
-                        <span class="w-1.5 h-1.5 rounded-full bg-green-500"></span>
+                    <p class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-white/5 border border-white/10 text-[11px] font-medium text-ae-200 mb-7 uppercase tracking-wider">
+                        <span class="w-1.5 h-1.5 rounded-full bg-brand-500 animate-pulse"></span>
                         Active contributors to the Frappe ecosystem
                     </p>
 
-                    <h1 class="text-4xl sm:text-5xl lg:text-[3.4rem] font-extrabold tracking-tight leading-[1.08] text-ae-950">
-                        Hire from the team that contributes to your ERPNext
+                    <h1 class="font-semibold tracking-tight leading-[1.15] text-white" style="font-size: clamp(1.5rem, 4.4vw, 3.25rem);">
+                        Hire from the team that <span class="text-brand-400 font-semibold">contributes</span> to your ERPNext.
                     </h1>
 
-                    <p class="mt-6 text-lg text-ae-500 leading-relaxed">
-                        Aerele's engineers have 600+ pull requests merged into Frappe, ERPNext, HRMS, and more. Active contributors to the framework your business runs on.
+                    <p class="mt-6 text-lg text-ae-200 leading-relaxed max-w-xl">
+                        Aerele's engineers have <span class="text-white font-medium">600+ pull requests</span> merged into Frappe, ERPNext, HRMS, and more — active contributors to the framework your business runs on.
                     </p>
 
-                    <p class="mt-3 text-base text-ae-400">
+                    <p class="mt-3 text-base text-ae-400 max-w-xl leading-relaxed">
                         Need a developer who already knows the codebase? Hire one of ours for your product, integration, or optimization project.
                     </p>
 
-                    <div class="mt-8 flex flex-wrap gap-4">
-                        <a href="#contact" class="px-6 py-3 bg-ae-900 text-ae-50 rounded-full text-sm font-medium hover:bg-ae-800 transition-colors">Start a conversation</a>
-                        <a href="#work" class="px-6 py-3 border border-ae-300 text-ae-700 rounded-full text-sm font-medium hover:border-ae-400 transition-colors">See the proof</a>
+                    <div class="mt-8 flex flex-wrap gap-3">
+                        <a href="#contact" class="inline-flex items-center gap-2 px-5 py-2.5 bg-brand-500 text-white rounded-lg text-sm font-medium hover:bg-brand-600 transition-colors">Start a conversation <span aria-hidden="true">→</span></a>
+                        <a href="#work" class="inline-flex items-center px-5 py-2.5 border border-white/15 text-white rounded-lg text-sm font-medium hover:bg-white/5 transition-colors">See the proof</a>
+                    </div>
+
+                    <!-- Hero stats -->
+                    <div class="mt-10 flex flex-wrap items-baseline gap-x-8 gap-y-3 text-xs text-ae-500 border-t border-white/10 pt-5">
+                        <div><span class="text-base font-semibold text-ae-100">30+</span> <span class="ml-1">developers</span></div>
+                        <div><span class="text-base font-semibold text-ae-100">600+</span> <span class="ml-1">core contributions</span></div>
+                        <div><span class="text-base font-semibold text-ae-100">100+</span> <span class="ml-1">customer repos</span></div>
                     </div>
                 </div>
 
-                <!-- Live PR ticker -->
-                <div class="relative w-full lg:w-[340px] h-[280px] lg:h-[400px] shrink-0 mt-10 lg:mt-2">
-                    <div class="absolute inset-0 rounded-xl bg-ae-950 overflow-hidden">
-                        <div class="absolute top-0 left-0 right-0 h-16 bg-gradient-to-b from-ae-950 to-transparent z-10"></div>
-                        <div class="absolute bottom-0 left-0 right-0 h-16 bg-gradient-to-t from-ae-950 to-transparent z-10"></div>
-                        <div class="absolute top-0 left-0 right-0 z-20 px-4 pt-3 pb-2">
-                            <div class="flex items-center gap-2">
-                                <span class="w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse"></span>
-                                <span class="text-[10px] uppercase tracking-widest text-ae-500 font-medium">Live from GitHub – merged this week</span>
-                            </div>
+                <!-- Live PR ticker (Mac-style code window) -->
+                <div class="relative w-full lg:flex-1 lg:max-w-[560px] h-[360px] lg:h-[460px] shrink-0 mt-12 lg:mt-0">
+                    <div class="absolute inset-0 rounded-xl bg-ae-950 border border-white/10 shadow-2xl shadow-black/40 overflow-hidden">
+                        <!-- Traffic lights -->
+                        <div class="flex items-center gap-1.5 px-4 py-3 border-b border-white/5 bg-black/30">
+                            <span class="w-2.5 h-2.5 rounded-full bg-[#ff5f57]"></span>
+                            <span class="w-2.5 h-2.5 rounded-full bg-[#febc2e]"></span>
+                            <span class="w-2.5 h-2.5 rounded-full bg-[#28c840]"></span>
+                            <span class="ml-3 text-[11px] font-mono text-ae-300">tail -f merged-prs.log</span>
+                            <span class="ml-auto inline-flex items-center gap-1.5 text-[10px] uppercase tracking-widest text-brand-400 font-medium">
+                                <span class="w-1.5 h-1.5 rounded-full bg-brand-500 animate-pulse"></span>
+                                live
+                            </span>
                         </div>
-                        <div class="absolute inset-0 pt-10 overflow-hidden">
-                            <div id="pr-ticker" class="flex flex-col gap-1 animate-scroll-vertical"></div>
+                        <div class="relative h-[calc(100%-42px)]">
+                            <div class="absolute top-0 left-0 right-0 h-10 bg-gradient-to-b from-ae-950 to-transparent z-10 pointer-events-none"></div>
+                            <div class="absolute bottom-0 left-0 right-0 h-10 bg-gradient-to-t from-ae-950 to-transparent z-10 pointer-events-none"></div>
+                            <div class="absolute inset-0 pt-3 overflow-hidden">
+                                <div id="pr-ticker" class="flex flex-col gap-1 animate-scroll-vertical"></div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -344,7 +371,7 @@
 
     <!-- ===== SOCIAL PROOF BAR ===== -->
     <section class="py-10 border-y border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6 text-center">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8 text-center">
             <p class="text-xs text-ae-400 uppercase tracking-widest mb-6">Companies that chose Aerele</p>
             <div class="flex flex-wrap justify-center items-center gap-x-8 gap-y-3">
                 <span class="text-sm font-semibold text-ae-900 whitespace-nowrap">Frappe Technologies</span>
@@ -421,9 +448,9 @@
 
     <!-- ===== THE QUESTION ===== -->
     <section id="why" class="py-24 sm:py-32">
-        <div class="max-w-5xl mx-auto px-6">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
             <div class="max-w-3xl mx-auto text-center fade-in">
-                <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight text-ae-950 leading-tight">
+                <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950">
                     Why do companies choose us over<br>other Frappe service providers?
                 </h2>
                 <p class="mt-6 text-ae-500 text-lg leading-relaxed">Because there's a difference between teams that <em>use</em> ERPNext and teams that <em>contribute</em> to it.</p>
@@ -433,28 +460,28 @@
                 <!-- Differentiator 1 -->
                 <div class="p-7 rounded-xl bg-white border border-ae-200/60">
                     <p class="text-xs text-ae-400 uppercase tracking-widest mb-4">The proof</p>
-                    <h3 class="text-lg font-bold text-ae-950 mb-2">We work where the framework lives</h3>
+                    <h3 class="text-base font-semibold text-ae-950 mb-2">We work where the framework lives</h3>
                     <p class="text-sm text-ae-500 leading-relaxed">Our team doesn't just file issues – we submit fixes, build features, and get them merged upstream. The people working on your project are the same ones improving the framework for everyone.</p>
                 </div>
 
                 <!-- Differentiator 2 -->
                 <div class="p-7 rounded-xl bg-white border border-ae-200/60">
                     <p class="text-xs text-ae-400 uppercase tracking-widest mb-4">The depth</p>
-                    <h3 class="text-lg font-bold text-ae-950 mb-2">600+ contributions to the core</h3>
+                    <h3 class="text-base font-semibold text-ae-950 mb-2">600+ contributions to the core</h3>
                     <p class="text-sm text-ae-500 leading-relaxed">Bug fixes, features, and performance improvements – merged upstream. When we debug your issue, we're often looking at code we contributed or reviewed.</p>
                 </div>
 
                 <!-- Differentiator 3 -->
                 <div class="p-7 rounded-xl bg-white border border-ae-200/60">
                     <p class="text-xs text-ae-400 uppercase tracking-widest mb-4">The results</p>
-                    <h3 class="text-lg font-bold text-ae-950 mb-2">8-hour jobs → under a minute</h3>
+                    <h3 class="text-base font-semibold text-ae-950 mb-2">8-hour jobs → under a minute</h3>
                     <p class="text-sm text-ae-500 leading-relaxed">We don't just write code – we make existing code faster. Deep profiling, query optimization, architectural refactoring. We've turned day-long batch processes into sub-minute operations.</p>
                 </div>
 
                 <!-- Differentiator 4 -->
                 <div class="p-7 rounded-xl bg-white border border-ae-200/60">
                     <p class="text-xs text-ae-400 uppercase tracking-widest mb-4">The integrity</p>
-                    <h3 class="text-lg font-bold text-ae-950 mb-2">We help you outgrow us</h3>
+                    <h3 class="text-base font-semibold text-ae-950 mb-2">We help you outgrow us</h3>
                     <p class="text-sm text-ae-500 leading-relaxed">We don't build lock-in. We recommend you build an internal team alongside our engagement. Most of our clients do – and they still come back for the hard problems.</p>
                 </div>
             </div>
@@ -463,10 +490,10 @@
 
     <!-- ===== WHAT WE DO ===== -->
     <section class="py-20 sm:py-28 bg-ae-950 text-ae-50">
-        <div class="max-w-5xl mx-auto px-6">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
             <div class="fade-in">
                 <p class="text-xs text-ae-500 uppercase tracking-widest mb-3">What we do</p>
-                <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight">Four ways to work with us</h2>
+                <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2]">Four ways to work with us</h2>
             </div>
 
             <div class="mt-14 grid grid-cols-1 sm:grid-cols-2 gap-8 fade-in">
@@ -492,17 +519,17 @@
 
     <!-- ===== OUR WORK ===== -->
     <section id="work" class="py-20 sm:py-28">
-        <div class="max-w-5xl mx-auto px-6">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
             <div class="fade-in">
                 <p class="text-xs text-ae-400 uppercase tracking-widest mb-3">The proof</p>
-                <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight text-ae-950">Don't take our word for it.<br>Read the code.</h2>
+                <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950">Don't take our word for it.<br>Read the code.</h2>
             </div>
 
             <!-- Case Studies -->
             <div class="mt-14 space-y-6 fade-in">
                 <div class="p-8 rounded-xl bg-white border border-ae-200/60">
                     <div class="flex flex-wrap items-center gap-3 mb-3">
-                        <h3 class="text-lg font-bold text-ae-950">India Banking Suite</h3>
+                        <h3 class="text-base font-semibold text-ae-950">India Banking Suite</h3>
                         <a href="https://github.com/aerele/india-banking" target="_blank" rel="noopener" class="text-xs text-ae-400 hover:text-ae-700 underline">GitHub →</a>
                     </div>
                     <p class="text-sm text-ae-500 leading-relaxed mb-4">Open-source ERPNext integration supporting <strong>12+ Indian banks</strong> – HDFC, ICICI, Axis, Kotak, YES, Union Bank, Canara, Bank of Baroda, IDFC, HSBC, Citi, SCB, and more. Vendor payouts, payroll payouts, statement reconciliation, and virtual account receipts. <a href="https://frappe.io/incubator/project/India%20Banking" target="_blank" rel="noopener" class="underline text-ae-700">Under Frappe's Incubation Program →</a></p>
@@ -518,7 +545,7 @@
 
                 <div class="p-8 rounded-xl bg-white border border-ae-200/60">
                     <div class="flex flex-wrap items-center gap-3 mb-3">
-                        <h3 class="text-lg font-bold text-ae-950">Warehouse Robotics × ERPNext</h3>
+                        <h3 class="text-base font-semibold text-ae-950">Warehouse Robotics × ERPNext</h3>
                         <span class="text-xs text-ae-400">Alfarsi National Enterprises, Oman</span>
                     </div>
                     <p class="text-sm text-ae-500 leading-relaxed">Direct connection between ERPNext and warehouse robotics systems. Orders trigger automated conveyor belt delivery. Returns go back and are stored in racks automatically. Real-time sync between ERP and physical warehouse operations.</p>
@@ -573,10 +600,10 @@
 
     <!-- ===== TEAM ===== -->
     <section id="team" class="py-20 sm:py-28 bg-white border-y border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
             <div class="fade-in">
                 <p class="text-xs text-ae-400 uppercase tracking-widest mb-3">The team</p>
-                <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight text-ae-950">30+ contributors. 600+ merged PRs.</h2>
+                <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950">30+ contributors. 600+ merged PRs.</h2>
                 <p class="mt-4 text-ae-500 max-w-xl">Every person on this list has code merged into the Frappe ecosystem. These are the engineers you'd be working with.</p>
             </div>
 
@@ -588,25 +615,25 @@
 
     <!-- ===== HOW WE WORK ===== -->
     <section class="py-20 sm:py-28">
-        <div class="max-w-5xl mx-auto px-6">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
             <div class="fade-in text-center max-w-2xl mx-auto">
                 <p class="text-xs text-ae-400 uppercase tracking-widest mb-3">How it works</p>
-                <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight text-ae-950">Three steps. No bureaucracy.</h2>
+                <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950">Three steps. No bureaucracy.</h2>
             </div>
 
-            <div class="mt-14 grid grid-cols-1 sm:grid-cols-3 gap-8 fade-in">
-                <div class="text-center">
-                    <div class="inline-flex items-center justify-center w-10 h-10 rounded-full bg-ae-950 text-ae-50 text-sm font-bold mb-4">1</div>
+            <div class="mt-14 grid grid-cols-1 sm:grid-cols-3 gap-6 fade-in">
+                <div class="relative p-7 rounded-xl bg-white border border-ae-200/60">
+                    <div class="font-mono text-5xl font-bold text-ae-100 leading-none mb-4">01</div>
                     <h3 class="text-base font-semibold text-ae-900 mb-2">Tell us the problem</h3>
                     <p class="text-sm text-ae-500 leading-relaxed">New product on Frappe, integration that doesn't exist, slow ERP, or need a dedicated developer. We scope it together.</p>
                 </div>
-                <div class="text-center">
-                    <div class="inline-flex items-center justify-center w-10 h-10 rounded-full bg-ae-950 text-ae-50 text-sm font-bold mb-4">2</div>
+                <div class="relative p-7 rounded-xl bg-white border border-ae-200/60">
+                    <div class="font-mono text-5xl font-bold text-ae-100 leading-none mb-4">02</div>
                     <h3 class="text-base font-semibold text-ae-900 mb-2">Choose your model</h3>
                     <p class="text-sm text-ae-500 leading-relaxed">Dedicated engineer on your team, or focused 3-week sprints. Both backed by our full engineering bench.</p>
                 </div>
-                <div class="text-center">
-                    <div class="inline-flex items-center justify-center w-10 h-10 rounded-full bg-ae-950 text-ae-50 text-sm font-bold mb-4">3</div>
+                <div class="relative p-7 rounded-xl bg-white border border-ae-200/60">
+                    <div class="font-mono text-5xl font-bold text-ae-100 leading-none mb-4">03</div>
                     <h3 class="text-base font-semibold text-ae-900 mb-2">We deliver. You ship.</h3>
                     <p class="text-sm text-ae-500 leading-relaxed">Production-grade code, documented and tested. We also help you build internal capability – you shouldn't depend on any vendor forever.</p>
                 </div>
@@ -616,20 +643,20 @@
 
     <!-- ===== PRICING ===== -->
     <section id="pricing" class="py-20 sm:py-28 bg-white border-y border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
             <div class="fade-in text-center max-w-2xl mx-auto">
                 <p class="text-xs text-ae-400 uppercase tracking-widest mb-3">Pricing</p>
-                <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight text-ae-950">No hidden costs. No surprise invoices.</h2>
+                <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950">No hidden costs. No surprise invoices.</h2>
                 <p class="text-sm text-ae-500 mt-3">Every competitor hides pricing behind a "schedule a call." We don't.</p>
             </div>
 
-            <div class="mt-14 grid grid-cols-1 sm:grid-cols-3 gap-6 max-w-4xl mx-auto fade-in">
+            <div class="mt-14 grid grid-cols-1 sm:grid-cols-3 gap-6 fade-in">
                 <!-- Hourly -->
                 <div class="p-7 rounded-xl border border-ae-200/60 flex flex-col">
-                    <h3 class="text-lg font-bold text-ae-950 mb-1">Hourly</h3>
+                    <h3 class="text-base font-semibold text-ae-950 mb-1">Hourly</h3>
                     <p class="text-sm text-ae-400 mb-6">Small, impactful changes</p>
                     <div class="mb-6">
-                        <span class="text-3xl font-extrabold text-ae-950">₹2,500–3,500</span>
+                        <span class="text-[1.75rem] font-semibold tracking-tight text-ae-950">₹2,500–3,500</span>
                         <span class="text-sm text-ae-400"> / hour + taxes</span>
                     </div>
                     <ul class="space-y-3 text-sm text-ae-600 mb-8 flex-grow">
@@ -641,14 +668,14 @@
                 </div>
 
                 <!-- Dedicated Resource -->
-                <div class="p-7 rounded-xl bg-ae-950 text-ae-50 flex flex-col">
+                <div class="relative p-7 rounded-xl bg-ae-900 text-white flex flex-col ring-1 ring-brand-500/20 shadow-xl shadow-brand-500/10">
                     <div class="flex items-center justify-between mb-1">
-                        <h3 class="text-lg font-bold">Dedicated Resource</h3>
-                        <span class="px-2.5 py-0.5 bg-white/10 rounded-full text-[10px] uppercase tracking-wider">Popular</span>
+                        <h3 class="text-base font-semibold">Dedicated Resource</h3>
+                        <span class="px-2.5 py-0.5 bg-brand-500 text-white rounded-full text-[10px] uppercase tracking-wider font-semibold">Popular</span>
                     </div>
                     <p class="text-sm text-ae-400 mb-6">Full-time developer on your project · Quarterly commitment</p>
                     <div class="mb-6">
-                        <span class="text-3xl font-extrabold">₹5,500–8,000</span>
+                        <span class="text-[1.75rem] font-semibold tracking-tight">₹5,500–8,000</span>
                         <span class="text-sm text-ae-400"> / working day + taxes</span>
                     </div>
                     <ul class="space-y-3 text-sm text-ae-200 mb-8 flex-grow">
@@ -662,10 +689,10 @@
 
                 <!-- Sprint -->
                 <div class="p-7 rounded-xl border border-ae-200/60 flex flex-col">
-                    <h3 class="text-lg font-bold text-ae-950 mb-1">Development Sprint</h3>
+                    <h3 class="text-base font-semibold text-ae-950 mb-1">Development Sprint</h3>
                     <p class="text-sm text-ae-400 mb-6">2 weeks dev + 1 week implementation</p>
                     <div class="mb-6">
-                        <span class="text-3xl font-extrabold text-ae-950">₹1,50,000</span>
+                        <span class="text-[1.75rem] font-semibold tracking-tight text-ae-950">₹1,50,000</span>
                         <span class="text-sm text-ae-400"> / sprint + taxes</span>
                     </div>
                     <ul class="space-y-3 text-sm text-ae-600 mb-8 flex-grow">
@@ -678,31 +705,31 @@
             </div>
 
             <!-- Which model suits you -->
-            <div class="mt-12 max-w-3xl mx-auto fade-in">
-                <h3 class="text-lg font-bold text-center mb-6">Which model fits?</h3>
-                <div class="grid sm:grid-cols-3 gap-4 text-xs text-ae-500">
-                    <div class="bg-ae-50 border border-ae-200/60 rounded-lg p-4">
-                        <p class="font-semibold text-ae-900 mb-2">Hourly works when:</p>
-                        <ul class="space-y-1.5">
+            <div class="mt-12 fade-in">
+                <h3 class="text-base font-semibold text-center mb-6">Which model fits?</h3>
+                <div class="grid sm:grid-cols-3 gap-4 text-sm text-ae-500 leading-relaxed">
+                    <div class="bg-ae-50 border border-ae-200/60 rounded-lg p-5">
+                        <p class="font-semibold text-ae-900 mb-3">Hourly works when:</p>
+                        <ul class="space-y-2">
                             <li>→ Quick bug fix or patch needed</li>
                             <li>→ One-off code review</li>
                             <li>→ Architecture consultation</li>
                             <li>→ Small feature under a few days</li>
                         </ul>
                     </div>
-                    <div class="bg-ae-50 border border-ae-200/60 rounded-lg p-4">
-                        <p class="font-semibold text-ae-900 mb-2">Dedicated works when:</p>
-                        <ul class="space-y-1.5">
+                    <div class="bg-ae-50 border border-ae-200/60 rounded-lg p-5">
+                        <p class="font-semibold text-ae-900 mb-3">Dedicated works when:</p>
+                        <ul class="space-y-2">
                             <li>→ You have functional expertise, need technical depth</li>
                             <li>→ Frappe partners outsourcing complex development</li>
                             <li>→ Code takeover, upgrade prep, maintainability</li>
                             <li>→ Multi-quarter product or platform work</li>
                         </ul>
-                        <p class="mt-2 text-[10px] text-ae-400">Minimum quarterly commitment · Limited slots</p>
+                        <p class="mt-3 text-xs text-ae-400">Minimum quarterly commitment · Limited slots</p>
                     </div>
-                    <div class="bg-ae-50 border border-ae-200/60 rounded-lg p-4">
-                        <p class="font-semibold text-ae-900 mb-2">Sprint works when:</p>
-                        <ul class="space-y-1.5">
+                    <div class="bg-ae-50 border border-ae-200/60 rounded-lg p-5">
+                        <p class="font-semibold text-ae-900 mb-3">Sprint works when:</p>
+                        <ul class="space-y-2">
                             <li>→ Scoped integration or custom app</li>
                             <li>→ Performance optimization project</li>
                             <li>→ Fixed deliverable, fixed budget</li>
@@ -716,10 +743,10 @@
 
     <!-- ===== FAQ ===== -->
     <section id="faq" class="py-20 sm:py-28">
-        <div class="max-w-3xl mx-auto px-6">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
             <div class="fade-in text-center">
                 <p class="text-xs text-ae-400 uppercase tracking-widest mb-3">FAQ</p>
-                <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight text-ae-950">Common questions</h2>
+                <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950">Common questions</h2>
             </div>
 
             <div class="mt-14 space-y-6 fade-in">
@@ -776,17 +803,17 @@
 
     <!-- ===== FINAL CTA ===== -->
     <section id="contact" class="py-24 sm:py-32">
-        <div class="max-w-5xl mx-auto px-6">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
             <div class="max-w-2xl mx-auto text-center fade-in">
-                <h2 class="text-3xl sm:text-4xl font-extrabold tracking-tight text-ae-950">
+                <h2 class="text-[1.625rem] sm:text-3xl md:text-[2.25rem] font-semibold tracking-tight leading-[1.2] text-ae-950">
                     Your next Frappe developer should be a contributor
                 </h2>
                 <p class="mt-6 text-ae-500 text-lg leading-relaxed">
                     Tell us what you're working on. If it involves Frappe, you're talking to the right team.
                 </p>
-                <div class="mt-8 flex flex-wrap justify-center gap-4">
-                    <a href="mailto:hello@aerele.in" class="inline-flex px-8 py-4 bg-ae-900 text-ae-50 rounded-full text-sm font-medium hover:bg-ae-800 transition-colors">hello@aerele.in</a>
-                    <a href="tel:+917790844832" class="inline-flex px-8 py-4 border border-ae-300 text-ae-700 rounded-full text-sm font-medium hover:border-ae-400 transition-colors">+91 77908 44832</a>
+                <div class="mt-8 flex flex-wrap justify-center gap-3">
+                    <a href="mailto:hello@aerele.in" class="inline-flex items-center gap-2 px-5 py-2.5 bg-brand-500 text-white rounded-lg text-sm font-medium hover:bg-brand-600 transition-colors">hello@aerele.in <span aria-hidden="true">→</span></a>
+                    <a href="tel:+917790844832" class="inline-flex items-center px-5 py-2.5 border border-ae-300 text-ae-800 rounded-lg text-sm font-medium hover:border-ae-400 hover:bg-white transition-colors">+91 77908 44832</a>
                 </div>
             </div>
 
@@ -813,7 +840,7 @@
 
     <!-- Footer -->
     <footer class="border-t border-ae-200/60 py-10 bg-ae-50">
-        <div class="max-w-5xl mx-auto px-6">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
             <div class="grid grid-cols-2 sm:grid-cols-4 gap-8 mb-8 text-xs">
                 <div>
                     <p class="font-semibold text-ae-700 mb-3">Services</p>
@@ -880,14 +907,14 @@
                     
                 };
                 const build = () => prs.map(pr => {
-                    const title = pr.title.length > 52 ? pr.title.slice(0, 52) + '…' : pr.title;
-                    return `<a href="${pr.url}" target="_blank" rel="noopener" class="block px-4 py-2.5 mx-2 rounded-lg group hover:bg-white/5 transition-colors" style="background:${colors[pr.repo]||'rgba(241,245,249,0.1)'}">
-                        <div class="flex items-center gap-2 mb-1">
-                            <span class="text-[10px] font-medium" style="color:${tc[pr.repo]||'#94a3b8'}">${pr.repo}</span>
-                            <span class="text-[10px] text-ae-600">·</span>
-                            <span class="text-[10px] text-ae-500">${pr.author}</span>
+                    const title = pr.title.length > 78 ? pr.title.slice(0, 78) + '…' : pr.title;
+                    return `<a href="${pr.url}" target="_blank" rel="noopener" class="block px-4 py-3 mx-2 rounded-lg group hover:bg-white/5 transition-colors" style="background:${colors[pr.repo]||'rgba(241,245,249,0.1)'}">
+                        <div class="flex items-center gap-2 mb-1.5">
+                            <span class="text-xs font-mono font-medium" style="color:${tc[pr.repo]||'#94a3b8'}">${pr.repo}</span>
+                            <span class="text-xs text-ae-500">·</span>
+                            <span class="text-xs text-ae-400">${pr.author}</span>
                         </div>
-                        <div class="text-[11px] text-ae-300 leading-snug group-hover:text-ae-100 transition-colors">${title}</div>
+                        <div class="text-sm text-ae-200 leading-snug group-hover:text-white transition-colors">${title}</div>
                     </a>`;
                 }).join('');
                 ticker.innerHTML = build() + build();
@@ -914,11 +941,11 @@
                                 <div class="text-[11px] text-ae-400">Software Development Engineer</div>
                             </div>
                             <div class="ml-auto text-right">
-                                <div class="text-lg font-bold text-ae-950">${c.total_merged_prs}</div>
+                                <div class="text-base font-semibold text-ae-950">${c.total_merged_prs}</div>
                                 <div class="text-[10px] text-ae-400">PRs</div>
                             </div>
                         </div>
-                        <p class="text-xs text-ae-500 leading-relaxed mb-3">${c.summary || ''}</p>
+                        <p class="text-sm text-ae-500 leading-relaxed mb-3">${c.summary || ''}</p>
                         <div class="flex flex-wrap gap-1">${tags}</div>`;
                     grid.appendChild(card);
                 });

--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -43,44 +43,70 @@
                 extend: {
                     colors: {
                         'ae': {
-                            50: '#fafaf9', 100: '#f0efed', 200: '#e2e0dc', 300: '#c8c4be',
-                            400: '#a9a49b', 500: '#918b80', 600: '#7a746a', 700: '#5e5a52',
-                            800: '#3d3a35', 900: '#1c1b18', 950: '#0d0c0b',
+                            50:  '#f7f8fb', 100: '#eef2fb', 200: '#e4e9f5', 300: '#c9d2e8',
+                            400: '#94a3b8', 500: '#64748b', 600: '#475569', 700: '#1e293b',
+                            800: '#0a1a3f', 900: '#060f2b', 950: '#05102a',
+                        },
+                        'brand': {
+                            50:  '#ecfdf5', 100: '#d1fae5', 200: '#a7f3d0', 300: '#6ee7b7',
+                            400: '#34d399', 500: '#10b981', 600: '#059669', 700: '#047857',
+                            800: '#065f46', 900: '#064e3b',
                         }
                     },
-                    fontFamily: { sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'] }
+                    fontFamily: {
+                        sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
+                    }
                 }
             }
         }
     </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-    <style>html{scroll-behavior:smooth;overflow-x:hidden}body{overflow-x:hidden;font-family:'Inter',system-ui,sans-serif}</style>
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" as="style">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="preload" href="/logo-nav.png" as="image">
+    <style>
+        html { scroll-behavior: smooth; overflow-x: hidden; }
+        body { font-family: 'Inter', system-ui, sans-serif; overflow-x: hidden; }
+        .fade-in { opacity: 0; transform: translateY(16px); transition: opacity 0.5s ease, transform 0.5s ease; }
+        .fade-in.visible { opacity: 1; transform: translateY(0); }
+        .hero-glow { background: radial-gradient(ellipse 80% 60% at 30% 30%, rgba(16,185,129,0.08), transparent 70%), radial-gradient(ellipse 60% 50% at 80% 20%, rgba(26,50,116,0.4), transparent 70%); }
+    </style>
 </head>
 <body class="bg-ae-50 text-ae-900 antialiased">
 
-    <nav class="fixed top-0 w-full bg-ae-50/80 backdrop-blur-md z-50 border-b border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
-            <a href="/" class="flex items-center gap-2.5"><img src="/logo-nav.png" alt="Aerele Technologies" class="h-8"><span class="text-[15px] font-semibold text-ae-900 tracking-tight">Aerele Technologies</span></a>
-            <div class="hidden sm:flex items-center gap-8 text-[13px] text-ae-500">
-                <a href="/" class="hover:text-ae-900">Home</a>
-                <a href="/about/" class="hover:text-ae-900">About</a>
-                <a href="tel:+917790844832" class="px-4 py-1.5 bg-ae-900 text-ae-50 rounded-full hover:bg-ae-800">Get in touch</a>
+    <nav class="fixed top-0 w-full bg-white/90 backdrop-blur-md z-50 border-b border-ae-200/60">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8 py-4 flex items-center justify-between">
+            <a href="/" class="flex items-center gap-2.5">
+                <img src="/logo-nav.png" alt="Aerele Technologies" class="h-8">
+                <span class="text-[16px] font-semibold text-ae-900 tracking-tight">Aerele Technologies</span>
+            </a>
+            <div class="hidden sm:flex items-center gap-8 text-[14px] font-medium text-ae-600">
+                <a href="/" class="hover:text-ae-900 transition-colors">Home</a>
+                <a href="/hire-frappe-developer/" class="hover:text-ae-900 transition-colors">Hire Developers</a>
+                <a href="/erpnext-customization/" class="hover:text-ae-900 transition-colors">Customization</a>
+                <a href="/erpnext-integration/" class="hover:text-ae-900 transition-colors">Integrations</a>
+                <a href="/about/" class="hover:text-ae-900 transition-colors">About</a>
+                <a href="/hire-frappe-developer/" class="inline-flex items-center gap-1.5 px-4 py-2 bg-ae-900 text-white rounded-lg font-semibold hover:bg-ae-800 transition-colors">Hire us <span aria-hidden="true">→</span></a>
             </div>
+            <button class="sm:hidden p-2 text-ae-600" aria-label="Menu">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
+            </button>
         </div>
     </nav>
 
-    <section class="pt-32 pb-8">
-        <div class="max-w-3xl mx-auto px-6">
-            <p class="text-xs text-ae-400 mb-4"><a href="/" class="hover:text-ae-700">Aerele</a> → Privacy Policy</p>
-            <h1 class="text-3xl sm:text-4xl font-extrabold tracking-tight mb-4">Privacy Policy</h1>
-            <p class="text-sm text-ae-400">Last updated: March 12, 2025</p>
+    <section class="relative pt-28 pb-20 sm:pt-32 sm:pb-24 overflow-hidden bg-ae-900 text-white">
+        <div class="absolute inset-0 hero-glow pointer-events-none"></div>
+        <div class="relative max-w-7xl mx-auto px-6 sm:px-8">
+            <p class="text-xs text-ae-300 mb-4"><a href="/" class="hover:text-white">Aerele</a> → Privacy Policy</p>
+            <h1 class="font-semibold tracking-tight leading-[1.15] text-white mb-4" style="font-size: clamp(1.5rem, 4.4vw, 3.25rem);">Privacy Policy</h1>
+            <p class="text-sm text-ae-300">Last updated: March 12, 2025</p>
         </div>
     </section>
 
-    <section class="pb-20">
-        <div class="max-w-3xl mx-auto px-6 prose prose-sm prose-ae">
+    <section class="pb-20 pt-16">
+        <div class="max-w-3xl mx-auto px-6 sm:px-8 prose prose-sm prose-ae">
             <div class="space-y-8 text-sm text-ae-600 leading-relaxed">
 
                 <div>
@@ -238,7 +264,7 @@
     </section>
 
     <footer class="py-10 border-t border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
             <div class="flex flex-col sm:flex-row items-center justify-between gap-3">
                 <p class="text-xs text-ae-400">© 2025 Aerele Technologies Pvt Ltd · Tiruppur, India</p>
                 <div class="flex gap-6 text-xs text-ae-400">

--- a/terms-of-service/index.html
+++ b/terms-of-service/index.html
@@ -37,44 +37,70 @@
                 extend: {
                     colors: {
                         'ae': {
-                            50: '#fafaf9', 100: '#f0efed', 200: '#e2e0dc', 300: '#c8c4be',
-                            400: '#a9a49b', 500: '#918b80', 600: '#7a746a', 700: '#5e5a52',
-                            800: '#3d3a35', 900: '#1c1b18', 950: '#0d0c0b',
+                            50:  '#f7f8fb', 100: '#eef2fb', 200: '#e4e9f5', 300: '#c9d2e8',
+                            400: '#94a3b8', 500: '#64748b', 600: '#475569', 700: '#1e293b',
+                            800: '#0a1a3f', 900: '#060f2b', 950: '#05102a',
+                        },
+                        'brand': {
+                            50:  '#ecfdf5', 100: '#d1fae5', 200: '#a7f3d0', 300: '#6ee7b7',
+                            400: '#34d399', 500: '#10b981', 600: '#059669', 700: '#047857',
+                            800: '#065f46', 900: '#064e3b',
                         }
                     },
-                    fontFamily: { sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'] }
+                    fontFamily: {
+                        sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
+                    }
                 }
             }
         }
     </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-    <style>html{scroll-behavior:smooth;overflow-x:hidden}body{overflow-x:hidden;font-family:'Inter',system-ui,sans-serif}</style>
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" as="style">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="preload" href="/logo-nav.png" as="image">
+    <style>
+        html { scroll-behavior: smooth; overflow-x: hidden; }
+        body { font-family: 'Inter', system-ui, sans-serif; overflow-x: hidden; }
+        .fade-in { opacity: 0; transform: translateY(16px); transition: opacity 0.5s ease, transform 0.5s ease; }
+        .fade-in.visible { opacity: 1; transform: translateY(0); }
+        .hero-glow { background: radial-gradient(ellipse 80% 60% at 30% 30%, rgba(16,185,129,0.08), transparent 70%), radial-gradient(ellipse 60% 50% at 80% 20%, rgba(26,50,116,0.4), transparent 70%); }
+    </style>
 </head>
 <body class="bg-ae-50 text-ae-900 antialiased">
 
-    <nav class="fixed top-0 w-full bg-ae-50/80 backdrop-blur-md z-50 border-b border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
-            <a href="/" class="flex items-center gap-2.5"><img src="/logo-nav.png" alt="Aerele Technologies" class="h-8"><span class="text-[15px] font-semibold text-ae-900 tracking-tight">Aerele Technologies</span></a>
-            <div class="hidden sm:flex items-center gap-8 text-[13px] text-ae-500">
-                <a href="/" class="hover:text-ae-900">Home</a>
-                <a href="/about/" class="hover:text-ae-900">About</a>
-                <a href="tel:+917790844832" class="px-4 py-1.5 bg-ae-900 text-ae-50 rounded-full hover:bg-ae-800">Get in touch</a>
+    <nav class="fixed top-0 w-full bg-white/90 backdrop-blur-md z-50 border-b border-ae-200/60">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8 py-4 flex items-center justify-between">
+            <a href="/" class="flex items-center gap-2.5">
+                <img src="/logo-nav.png" alt="Aerele Technologies" class="h-8">
+                <span class="text-[16px] font-semibold text-ae-900 tracking-tight">Aerele Technologies</span>
+            </a>
+            <div class="hidden sm:flex items-center gap-8 text-[14px] font-medium text-ae-600">
+                <a href="/" class="hover:text-ae-900 transition-colors">Home</a>
+                <a href="/hire-frappe-developer/" class="hover:text-ae-900 transition-colors">Hire Developers</a>
+                <a href="/erpnext-customization/" class="hover:text-ae-900 transition-colors">Customization</a>
+                <a href="/erpnext-integration/" class="hover:text-ae-900 transition-colors">Integrations</a>
+                <a href="/about/" class="hover:text-ae-900 transition-colors">About</a>
+                <a href="/hire-frappe-developer/" class="inline-flex items-center gap-1.5 px-4 py-2 bg-ae-900 text-white rounded-lg font-semibold hover:bg-ae-800 transition-colors">Hire us <span aria-hidden="true">→</span></a>
             </div>
+            <button class="sm:hidden p-2 text-ae-600" aria-label="Menu">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
+            </button>
         </div>
     </nav>
 
-    <section class="pt-32 pb-8">
-        <div class="max-w-3xl mx-auto px-6">
-            <p class="text-xs text-ae-400 mb-4"><a href="/" class="hover:text-ae-700">Aerele</a> → Terms of Service</p>
-            <h1 class="text-3xl sm:text-4xl font-extrabold tracking-tight mb-4">Terms of Service</h1>
-            <p class="text-sm text-ae-400">Last updated: March 12, 2025</p>
+    <section class="relative pt-28 pb-20 sm:pt-32 sm:pb-24 overflow-hidden bg-ae-900 text-white">
+        <div class="absolute inset-0 hero-glow pointer-events-none"></div>
+        <div class="relative max-w-7xl mx-auto px-6 sm:px-8">
+            <p class="text-xs text-ae-300 mb-4"><a href="/" class="hover:text-white">Aerele</a> → Terms of Service</p>
+            <h1 class="font-semibold tracking-tight leading-[1.15] text-white mb-4" style="font-size: clamp(1.5rem, 4.4vw, 3.25rem);">Terms of Service</h1>
+            <p class="text-sm text-ae-300">Last updated: March 12, 2025</p>
         </div>
     </section>
 
-    <section class="pb-20">
-        <div class="max-w-3xl mx-auto px-6">
+    <section class="pb-20 pt-16">
+        <div class="max-w-3xl mx-auto px-6 sm:px-8">
             <div class="space-y-8 text-sm text-ae-600 leading-relaxed">
 
                 <div>
@@ -178,7 +204,7 @@
     </section>
 
     <footer class="py-10 border-t border-ae-200/60">
-        <div class="max-w-5xl mx-auto px-6">
+        <div class="max-w-7xl mx-auto px-6 sm:px-8">
             <div class="flex flex-col sm:flex-row items-center justify-between gap-3">
                 <p class="text-xs text-ae-400">© 2025 Aerele Technologies Pvt Ltd · Tiruppur, India</p>
                 <div class="flex gap-6 text-xs text-ae-400">


### PR DESCRIPTION
## Summary

- Homepage and all 12 subpages redesigned to match **lens.aerele.in**'s visual language: navy-slate + emerald palette (`ae-*` / `brand-*`), Inter + JetBrains Mono typography, white fixed nav, dark hero with a single emerald accent, restrained semibold headings (no more extrabold shouting).
- Unified container width across nav, sections, and footer (`max-w-7xl mx-auto px-6 sm:px-8`), so left/right edges line up on every page.
- Bundled the design system as a stack-agnostic Claude Code skill at `.claude/skills/aerele-design/SKILL.md` so devs on other Aerele products (any stack — Tailwind, plain CSS, CSS-in-JS, etc.) can apply the same principles.

## Pages updated (13)

- `index.html`
- `about/`
- `hire-frappe-developer/`, `hire-erpnext-developer/`
- `erpnext-customization/`, `erpnext-integration/`, `erpnext-performance-optimization/`
- `frappe-product-engineering/`
- `case-studies/india-banking/`, `case-studies/alfarsi-robotics/`
- `privacy-policy/`, `terms-of-service/`, `dpa/`

## Design system skill

New file: `.claude/skills/aerele-design/SKILL.md` (686 lines).

Stack-agnostic primary spec (raw hex colors, rem sizes, weight numbers, component specs described behaviorally), with three reference implementations in appendices:

- **Appendix A** — Tailwind (what this repo uses)
- **Appendix B** — Plain CSS with custom properties
- **Appendix C** — Tokens as JSON (for Figma / Style Dictionary)

Install options are documented in the skill itself (project-scoped `.claude/skills/` or user-scoped `~/.claude/skills/`).

## Test plan

- [ ] Homepage: nav, hero, PR ticker, social-proof bar, Frappeverse callout, "Why us" cards, "Four ways to work" dark section, open-source apps grid, team grid, how-it-works steps, pricing tiers, FAQ, final CTA — all render correctly at desktop (1440px, 1600px) and mobile (375px)
- [ ] All 12 subpages: nav + dark hero appear with correct emerald accent, containers line up with the homepage, CTAs use `rounded-lg` (not pill)
- [ ] Mobile viewport (375px): no horizontal overflow, headings don't clip, nav collapses to hamburger
- [ ] Confirm no lingering references to the old stone/beige palette (`fafaf9`) or the old light nav (`bg-ae-50/80`)

## Notes

- Pre-existing content bug on `about/index.html` (orphan `</a>` near "Docker deployments" in the repos grid) was left untouched — it's a content-level issue outside this redesign's scope. Follow-up PR worth filing separately.
- Legal pages (privacy, terms, dpa) keep their compact `text-lg font-bold` section headings rather than the marketing-style H2s, since the dense numbered sections would look overwrought with large headings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)